### PR TITLE
Add manual workflows for selective Claude issue commenting

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -94,6 +94,37 @@ jobs:
 - **トリガー**: cron (1時間ごと)、手動実行 (workflow_dispatch)
 - **使用プラグイン**: claude-auto-implement.yml
 
+### simple-manual-claude-comment.yml
+
+**推奨**: 手動でissueにClaude実装依頼コメントを投稿するワークフロー（最もシンプル）。
+
+- **トリガー**: workflow_dispatch (手動実行のみ)
+- **機能**:
+  - Issue番号を空欄で実行 → 全てのopen issueをリスト表示
+  - Issue番号を入力して実行 → その番号のissueにコメント投稿
+- **使い方**:
+  1. Actions タブから "Simple Manual Claude Comment" を選択
+  2. "Run workflow" をクリック
+  3. Issue番号を空欄にして実行 → issueリストを確認
+  4. 再度実行して、コメントしたいissue番号を入力
+  5. 必要に応じてカスタムメッセージを入力
+  6. "Run workflow" をクリック
+
+### manual-claude-comment.yml
+
+手動でissueにClaude実装依頼コメントを投稿するワークフロー（モード選択式）。
+
+- **トリガー**: workflow_dispatch (手動実行のみ)
+- **モード**:
+  - `list-issues`: 全てのopen issueをリスト表示
+  - `comment-on-issue`: 指定したissueにコメント投稿
+- **使い方**:
+  1. Actions タブから "Manual Claude Comment on Issue" を選択
+  2. "Run workflow" をクリック
+  3. モードで "list-issues" を選択してissueリストを確認
+  4. 再度実行して、モードで "comment-on-issue" を選択
+  5. Issue番号とメッセージを入力して実行
+
 ### claude.yml
 
 Claudeに関連するワークフロー（詳細は要確認）

--- a/.github/workflows/manual-claude-comment.yml
+++ b/.github/workflows/manual-claude-comment.yml
@@ -1,0 +1,72 @@
+name: Manual Claude Comment on Issue
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'コメントモード'
+        required: true
+        type: choice
+        options:
+          - 'list-issues'
+          - 'comment-on-issue'
+        default: 'list-issues'
+      issue_number:
+        description: 'Issue番号 (comment-on-issueモード時に指定)'
+        required: false
+        type: number
+      comment_message:
+        description: 'カスタムコメントメッセージ (オプション)'
+        required: false
+        type: string
+
+jobs:
+  list-open-issues:
+    if: github.event.inputs.mode == 'list-issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+
+    steps:
+      - name: List all open issues
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            console.log('📋 Open Issues リスト\n');
+
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'created',
+              direction: 'desc',
+              per_page: 100
+            });
+
+            const issueList = issues.data
+              .filter(issue => !issue.pull_request)
+              .map(issue => {
+                return `#${issue.number}: ${issue.title}`;
+              });
+
+            if (issueList.length === 0) {
+              console.log('Open issueが見つかりませんでした。');
+            } else {
+              console.log(`全 ${issueList.length} 件のopen issues:\n`);
+              issueList.forEach(item => console.log(item));
+
+              console.log('\n\n📝 コメントするには:');
+              console.log('1. このワークフローを再度実行');
+              console.log('2. モードで "comment-on-issue" を選択');
+              console.log('3. Issue番号を入力');
+            }
+
+  comment-on-specific-issue:
+    if: github.event.inputs.mode == 'comment-on-issue' && github.event.inputs.issue_number != ''
+    uses: ./.github/workflows/claude-auto-implement.yml
+    with:
+      issue_number: ${{ fromJSON(github.event.inputs.issue_number) }}
+      comment_message: ${{ github.event.inputs.comment_message != '' && github.event.inputs.comment_message || '@claude pluginで使える形で実装して。実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。' }}
+    secrets:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/simple-manual-claude-comment.yml
+++ b/.github/workflows/simple-manual-claude-comment.yml
@@ -1,0 +1,137 @@
+name: Simple Manual Claude Comment
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue番号 (空欄の場合は全てのopen issueをリスト表示)'
+        required: false
+        type: string
+      comment_message:
+        description: 'カスタムコメントメッセージ (オプション)'
+        required: false
+        type: string
+
+jobs:
+  process-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: List issues or comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumberInput = '${{ github.event.inputs.issue_number }}';
+            const customMessage = '${{ github.event.inputs.comment_message }}';
+            const defaultMessage = '@claude pluginで使える形で実装して。実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。';
+            const commentMessage = customMessage || defaultMessage;
+
+            if (!issueNumberInput || issueNumberInput.trim() === '') {
+              // Issue番号が指定されていない場合はリスト表示
+              console.log('📋 Open Issues リスト\n');
+
+              const issues = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                sort: 'created',
+                direction: 'desc',
+                per_page: 100
+              });
+
+              const issueList = issues.data
+                .filter(issue => !issue.pull_request)
+                .map(issue => {
+                  const labels = issue.labels.map(l => l.name).join(', ');
+                  return {
+                    number: issue.number,
+                    title: issue.title,
+                    labels: labels,
+                    url: issue.html_url
+                  };
+                });
+
+              if (issueList.length === 0) {
+                console.log('❌ Open issueが見つかりませんでした。');
+              } else {
+                console.log(`✅ 全 ${issueList.length} 件のopen issues:\n`);
+                console.log('番号 | タイトル | ラベル');
+                console.log('-----|----------|--------');
+                issueList.forEach(item => {
+                  console.log(`#${item.number} | ${item.title} | ${item.labels || 'なし'}`);
+                });
+
+                console.log('\n\n📝 次のステップ:');
+                console.log('1. このワークフローを再度実行');
+                console.log('2. "Issue番号" フィールドにコメントしたいissue番号を入力');
+                console.log('   例: 46');
+                console.log('3. 必要に応じて "カスタムコメントメッセージ" を入力');
+                console.log('4. "Run workflow" をクリック');
+              }
+            } else {
+              // Issue番号が指定されている場合はコメント
+              const issueNumber = parseInt(issueNumberInput.trim());
+
+              if (isNaN(issueNumber)) {
+                core.setFailed(`無効なissue番号: ${issueNumberInput}`);
+                return;
+              }
+
+              console.log(`📝 Issue #${issueNumber} にコメントします...`);
+
+              try {
+                // Issueの取得
+                const issue = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber
+                });
+
+                // Pull Requestは除外
+                if (issue.data.pull_request) {
+                  console.log(`❌ Issue #${issueNumber} はPull Requestのため、スキップします。`);
+                  return;
+                }
+
+                console.log(`✅ Issue #${issueNumber}: ${issue.data.title}`);
+
+                // 既存のコメントをチェック
+                const comments = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber
+                });
+
+                const alreadyCommented = comments.data.some(comment =>
+                  comment.body.includes('@claude')
+                );
+
+                if (alreadyCommented) {
+                  console.log(`⚠️  Issue #${issueNumber} には既にClaudeコメントが存在します。`);
+                  console.log(`続行しますか？ (強制的にコメントを追加します)`);
+                }
+
+                // コメントを投稿
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: commentMessage
+                });
+
+                console.log(`✅ Issue #${issueNumber} にコメントしました！`);
+                console.log(`メッセージ: ${commentMessage}`);
+                console.log(`URL: ${issue.data.html_url}`);
+
+              } catch (error) {
+                core.setFailed(`エラー: ${error.message}`);
+              }
+            }


### PR DESCRIPTION
## 新規追加

### simple-manual-claude-comment.yml (推奨)
最もシンプルな手動実行ワークフロー:
- Issue番号を空欄で実行 → 全てのopen issueをリスト表示
- Issue番号を入力して実行 → 指定したissueにコメント投稿
- カスタムメッセージ対応
- 1つのワークフローで完結（プラグイン不使用）

使い方:
1. Actions → "Simple Manual Claude Comment" → Run workflow
2. Issue番号を空欄で実行 → issueリストを確認
3. 再実行して、issue番号を入力 → コメント投稿

### manual-claude-comment.yml
モード選択式の手動実行ワークフロー:
- `list-issues` モード: issueリストを表示
- `comment-on-issue` モード: claude-auto-implement.yml プラグインを呼び出してコメント投稿

## 更新

### .github/workflows/README.md
- 新しい手動ワークフローの説明を追加
- 使い方ガイドを記載
- 推奨ワークフローを明記

## 用途

自動実行ではなく、手動で選択的にissueにClaude実装依頼コメントを投稿したい場合に使用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)