### PR TITLE
Add branch naming instruction to Claude comment message

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -16,7 +16,7 @@ on:
         description: 'Custom comment message to post'
         required: false
         type: string
-        default: '@claude 実装して。実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。'
+        default: '@claude 実装して。branchを作る時はissueタイトルから推察したブランチ名にしてください。実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。'
     secrets:
       PAT_TOKEN:
         description: 'Personal Access Token for GitHub API'
@@ -58,7 +58,7 @@ jobs:
                 message += '実装して。';
               }
 
-              message += '実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。';
+              message += 'branchを作る時はissueタイトルから推察したブランチ名にしてください。実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。';
 
               console.log(`Labels: ${labels.join(', ')}`);
               console.log(`Custom message: ${message}`);


### PR DESCRIPTION
## 変更内容

### claude-auto-implement.yml
- **ブランチ命名指示を追加**
  - "branchを作る時はissueタイトルから推察したブランチ名にしてください" を追加
  - デフォルトメッセージとbuildCommentMessage関数の両方に適用

## 新しいメッセージフォーマット

### UE5 + feature ラベルの場合
```
@claude pluginで使える形で実装して。branchを作る時はissueタイトルから推察したブランチ名にしてください。実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。
```

### その他の場合
```
@claude 実装して。branchを作る時はissueタイトルから推察したブランチ名にしてください。実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。
```

## メリット

1. **一貫したブランチ命名**: issueタイトルに基づいた意味のあるブランチ名
2. **自動化の改善**: Claudeがブランチ名を適切に推測して作成
3. **トレーサビリティ**: ブランチ名からissueの内容が推測可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)