### PR TITLE
Fix permissions error in auto-comment-issues.yml

### DIFF
--- a/.github/workflows/auto-comment-issues.yml
+++ b/.github/workflows/auto-comment-issues.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 */1 * * *'
   workflow_dispatch: # 手動実行も可能
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
 jobs:
   comment-on-issues:
     uses: ./.github/workflows/claude-auto-implement.yml


### PR DESCRIPTION
## 問題
再利用可能なワークフロー呼び出し時の権限エラー:
```
The nested job 'auto-implement' is requesting 'contents: write, issues: write, pull-requests: read',
but is only allowed 'contents: read, issues: none, pull-requests: none'
```

## 原因
- `claude-auto-implement.yml` が要求する権限が不足
- 呼び出し元のワークフローに `permissions` が未定義

## 解決策
`auto-comment-issues.yml` に必要な権限を追加:
```yaml
permissions:
  contents: write
  issues: write
  pull-requests: read
```

これにより、呼び出される `claude-auto-implement.yml` が必要な権限で実行できるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)