### PR TITLE
Fix backtick escaping in JavaScript template literals

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -16,7 +16,7 @@ on:
         description: 'Custom comment message to post'
         required: false
         type: string
-        default: '@claude 実装して。branchを作る時はissueタイトルから推察したブランチ名にしてください。実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。'
+        default: '@claude 実装して。branchを作る時はissueタイトルから推察したブランチ名にしてください。実装が終わったらgh pr createコマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。'
     secrets:
       PAT_TOKEN:
         description: 'Personal Access Token for GitHub API'
@@ -58,7 +58,7 @@ jobs:
                 message += '実装して。';
               }
 
-              message += 'branchを作る時はissueタイトルから推察したブランチ名にしてください。実装が終わったら`gh pr create`コマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。';
+              message += 'branchを作る時はissueタイトルから推察したブランチ名にしてください。実装が終わったらgh pr createコマンドを使ってPullRequestをmainブランチに対して自動作成して。手動リンクは不要です。';
 
               console.log(`Labels: ${labels.join(', ')}`);
               console.log(`Custom message: ${message}`);


### PR DESCRIPTION
## 問題
GitHub Actionsでバッククォート(`)を含むメッセージがJavaScriptのテンプレートリテラル内でエラーを発生:
```
SyntaxError: Unexpected identifier 'gh'
```

## 原因
YAML内でバッククォートを含む文字列をJavaScriptテンプレートリテラルに埋め込む際、
バッククォートがテンプレートリテラルを終了させてしまい、構文エラーが発生。

変更前:
```javascript
message += 'branchを作る時は...実装が終わったら`gh pr create`コマンドを...'
```

YAMLから展開されると:
```javascript
const baseCommentMessage = `@claude ...`gh pr create`...`;
// ここでバッククォートが衝突
```

## 解決策
バッククォートを削除し、通常のテキストとして記述:
```javascript
message += 'branchを作る時は...実装が終わったらgh pr createコマンドを...'
```

## 影響範囲
- デフォルトメッセージ (default parameter)
- buildCommentMessage関数内のメッセージ生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)