### PR TITLE
Fix Claude workflow to allow PR comment modifications

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          # For PR comments, checkout the PR branch
+          ref: ${{ github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number) || github.ref }}
 
       - name: Run Claude Code
         id: claude
@@ -46,5 +48,8 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Allow file editing and gh commands for fixing PR issues
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
修正内容:
- allowed-toolsの制限を解除してファイル編集を可能に
- PR上のコメントに対して正しいブランチをチェックアウト
- git操作のためにGH_TOKENを環境変数として設定

これにより、PR上で「@claude 以下の問題を修正してください」とコメントされた際に、
Claudeが実際にファイルを編集してコミット・プッシュできるようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)