### PR TITLE
feat: Implement DebugConsoleCommands Plugin

### DIFF
--- a/Plugins/DebugConsoleCommands/DebugConsoleCommands.uplugin
+++ b/Plugins/DebugConsoleCommands/DebugConsoleCommands.uplugin
@@ -1,0 +1,24 @@
+{
+	"FileVersion": 3,
+	"Version": 1,
+	"VersionName": "1.0",
+	"FriendlyName": "Debug Console Commands",
+	"Description": "Developer console commands for gameplay testing and debugging",
+	"Category": "Developer",
+	"CreatedBy": "Antigravity",
+	"CreatedByURL": "",
+	"DocsURL": "",
+	"MarketplaceURL": "",
+	"SupportURL": "",
+	"CanContainContent": false,
+	"IsBetaVersion": false,
+	"IsExperimentalVersion": false,
+	"Installed": false,
+	"Modules": [
+		{
+			"Name": "DebugConsoleCommands",
+			"Type": "DeveloperTool",
+			"LoadingPhase": "Default"
+		}
+	]
+}

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/DebugConsoleCommands.Build.cs
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/DebugConsoleCommands.Build.cs
@@ -1,0 +1,38 @@
+// Copyright Antigravity. All Rights Reserved.
+
+using UnrealBuildTool;
+
+public class DebugConsoleCommands : ModuleRules
+{
+	public DebugConsoleCommands(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(
+			new string[]
+			{
+				"Core",
+				"CoreUObject",
+				"Engine",
+				"InputCore",
+				"AIModule",
+			}
+		);
+
+		PrivateDependencyModuleNames.AddRange(
+			new string[]
+			{
+			}
+		);
+
+		// Only include in non-shipping builds
+		if (Target.Configuration != UnrealTargetConfiguration.Shipping)
+		{
+			PublicDefinitions.Add("WITH_DEBUG_COMMANDS=1");
+		}
+		else
+		{
+			PublicDefinitions.Add("WITH_DEBUG_COMMANDS=0");
+		}
+	}
+}

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/CombatCommands.cpp
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/CombatCommands.cpp
@@ -1,0 +1,194 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#include "DebugCommandSubsystem.h"
+#include "DebugConsoleCommandsModule.h"
+#include "Engine/World.h"
+#include "Engine/DamageEvents.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Character.h"
+#include "EngineUtils.h"
+#include "AIController.h"
+#include "BrainComponent.h"
+
+#if WITH_DEBUG_COMMANDS
+
+namespace DebugCommands
+{
+	extern ACharacter* GetPlayerCharacter(UWorld* World);
+}
+
+void UDebugCommandSubsystem::RegisterCombatCommands()
+{
+	// SetHP - Set player health
+	RegisterNativeCommand(
+		TEXT("SetHP"),
+		TEXT("Set player's current HP"),
+		EDebugCommandCategory::Combat,
+		TEXT("SetHP <Amount>"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (Args.Num() < 1)
+			{
+				return TEXT("Usage: SetHP <Amount>");
+			}
+
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			float Amount = FCString::Atof(*Args[0]);
+			if (Amount < 0)
+			{
+				return TEXT("HP amount must be non-negative");
+			}
+
+			// Try to call a SetHP function via UFunction
+			UFunction* SetHPFunc = Character->FindFunction(TEXT("DebugSetHP"));
+			if (SetHPFunc)
+			{
+				struct { float HP; } Params = { Amount };
+				Character->ProcessEvent(SetHPFunc, &Params);
+				return FString::Printf(TEXT("HP set to %.1f"), Amount);
+			}
+
+			return FString::Printf(TEXT("SetHP %.1f requested (implement DebugSetHP function)"), Amount);
+		}
+	);
+
+	// SetMaxHP - Set player max health
+	RegisterNativeCommand(
+		TEXT("SetMaxHP"),
+		TEXT("Set player's maximum HP"),
+		EDebugCommandCategory::Combat,
+		TEXT("SetMaxHP <Amount>"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (Args.Num() < 1)
+			{
+				return TEXT("Usage: SetMaxHP <Amount>");
+			}
+
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			float Amount = FCString::Atof(*Args[0]);
+			if (Amount <= 0)
+			{
+				return TEXT("MaxHP must be greater than 0");
+			}
+
+			// Try to call a SetMaxHP function via UFunction
+			UFunction* SetMaxHPFunc = Character->FindFunction(TEXT("DebugSetMaxHP"));
+			if (SetMaxHPFunc)
+			{
+				struct { float MaxHP; } Params = { Amount };
+				Character->ProcessEvent(SetMaxHPFunc, &Params);
+				return FString::Printf(TEXT("MaxHP set to %.1f"), Amount);
+			}
+
+			return FString::Printf(TEXT("SetMaxHP %.1f requested (implement DebugSetMaxHP function)"), Amount);
+		}
+	);
+
+	// KillAllEnemies - Kill all enemies
+	RegisterNativeCommand(
+		TEXT("KillAllEnemies"),
+		TEXT("Kill all enemy characters in the level"),
+		EDebugCommandCategory::Combat,
+		TEXT("KillAllEnemies"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			int32 KillCount = 0;
+
+			// Find all characters with AI controllers (likely enemies)
+			for (TActorIterator<ACharacter> It(World); It; ++It)
+			{
+				ACharacter* Character = *It;
+
+				// Skip player-controlled characters
+				if (Character->IsPlayerControlled())
+				{
+					continue;
+				}
+
+				// Check if it has an AI controller
+				AAIController* AIController = Cast<AAIController>(Character->GetController());
+				if (AIController)
+				{
+					// Try to call a Kill function
+					UFunction* KillFunc = Character->FindFunction(TEXT("DebugKill"));
+					if (KillFunc)
+					{
+						Character->ProcessEvent(KillFunc, nullptr);
+					}
+					else
+					{
+						// Use TakeDamage as fallback
+						Character->TakeDamage(999999.0f, FDamageEvent(), nullptr, nullptr);
+					}
+					KillCount++;
+				}
+			}
+
+			return FString::Printf(TEXT("Killed %d enemies"), KillCount);
+		}
+	);
+
+	// ToggleAI - Toggle AI enabled/disabled
+	RegisterNativeCommand(
+		TEXT("ToggleAI"),
+		TEXT("Toggle AI behavior on/off for all AI characters"),
+		EDebugCommandCategory::Combat,
+		TEXT("ToggleAI"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			static bool bAIEnabled = true;
+			bAIEnabled = !bAIEnabled;
+
+			int32 AffectedCount = 0;
+
+			// Find all AI controllers
+			for (TActorIterator<AAIController> It(World); It; ++It)
+			{
+				AAIController* AIController = *It;
+				if (AIController)
+				{
+					UBrainComponent* BrainComp = AIController->GetBrainComponent();
+					if (BrainComp)
+					{
+						if (bAIEnabled)
+						{
+							BrainComp->RestartLogic();
+						}
+						else
+						{
+							BrainComp->StopLogic(TEXT("Debug command"));
+						}
+						AffectedCount++;
+					}
+				}
+			}
+
+			return FString::Printf(TEXT("AI %s (%d controllers affected)"),
+				bAIEnabled ? TEXT("enabled") : TEXT("disabled"),
+				AffectedCount);
+		}
+	);
+}
+
+#endif // WITH_DEBUG_COMMANDS

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/InfoCommands.cpp
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/InfoCommands.cpp
@@ -1,0 +1,216 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#include "DebugCommandSubsystem.h"
+#include "DebugConsoleCommandsModule.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Character.h"
+#include "GameFramework/CharacterMovementComponent.h"
+#include "GameFramework/Pawn.h"
+
+#if WITH_DEBUG_COMMANDS
+
+namespace DebugCommands
+{
+	extern ACharacter* GetPlayerCharacter(UWorld* World);
+
+	FString GetCategoryName(EDebugCommandCategory Category)
+	{
+		switch (Category)
+		{
+		case EDebugCommandCategory::Player:   return TEXT("Player");
+		case EDebugCommandCategory::Movement: return TEXT("Movement");
+		case EDebugCommandCategory::Combat:   return TEXT("Combat");
+		case EDebugCommandCategory::Spawn:    return TEXT("Spawn");
+		case EDebugCommandCategory::System:   return TEXT("System");
+		case EDebugCommandCategory::Info:     return TEXT("Info");
+		case EDebugCommandCategory::Custom:   return TEXT("Custom");
+		default: return TEXT("Unknown");
+		}
+	}
+}
+
+void UDebugCommandSubsystem::RegisterInfoCommands()
+{
+	// ListCommands - Show available commands
+	RegisterNativeCommand(
+		TEXT("ListCommands"),
+		TEXT("List all available debug commands"),
+		EDebugCommandCategory::Info,
+		TEXT("ListCommands [Category]"),
+		[this](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			FString Result;
+
+			// Filter by category if specified
+			EDebugCommandCategory FilterCategory = EDebugCommandCategory::Custom;
+			bool bHasFilter = false;
+
+			if (Args.Num() > 0)
+			{
+				FString CategoryName = Args[0].ToLower();
+				if (CategoryName == TEXT("player")) { FilterCategory = EDebugCommandCategory::Player; bHasFilter = true; }
+				else if (CategoryName == TEXT("movement")) { FilterCategory = EDebugCommandCategory::Movement; bHasFilter = true; }
+				else if (CategoryName == TEXT("combat")) { FilterCategory = EDebugCommandCategory::Combat; bHasFilter = true; }
+				else if (CategoryName == TEXT("spawn")) { FilterCategory = EDebugCommandCategory::Spawn; bHasFilter = true; }
+				else if (CategoryName == TEXT("system")) { FilterCategory = EDebugCommandCategory::System; bHasFilter = true; }
+				else if (CategoryName == TEXT("info")) { FilterCategory = EDebugCommandCategory::Info; bHasFilter = true; }
+				else if (CategoryName == TEXT("custom")) { FilterCategory = EDebugCommandCategory::Custom; bHasFilter = true; }
+			}
+
+			// Group commands by category
+			TMap<EDebugCommandCategory, TArray<FDebugCommand>> GroupedCommands;
+			for (const auto& Pair : Commands)
+			{
+				if (!bHasFilter || Pair.Value.Category == FilterCategory)
+				{
+					GroupedCommands.FindOrAdd(Pair.Value.Category).Add(Pair.Value);
+				}
+			}
+
+			// Build result string
+			Result = TEXT("Available Debug Commands:\n");
+			Result += TEXT("========================\n");
+
+			if (bHasFilter)
+			{
+				Result += FString::Printf(TEXT("[%s]\n"), *DebugCommands::GetCategoryName(FilterCategory));
+			}
+
+			for (const auto& CategoryPair : GroupedCommands)
+			{
+				if (!bHasFilter)
+				{
+					Result += FString::Printf(TEXT("\n[%s]\n"), *DebugCommands::GetCategoryName(CategoryPair.Key));
+				}
+
+				for (const FDebugCommand& Cmd : CategoryPair.Value)
+				{
+					Result += FString::Printf(TEXT("  %s - %s\n"), *Cmd.Name, *Cmd.Description);
+				}
+			}
+
+			Result += TEXT("\nUse 'Debug Help <command>' for detailed usage.");
+
+			return Result;
+		}
+	);
+
+	// Help - Show command help
+	RegisterNativeCommand(
+		TEXT("Help"),
+		TEXT("Show detailed help for a command"),
+		EDebugCommandCategory::Info,
+		TEXT("Help <CommandName>"),
+		[this](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (Args.Num() < 1)
+			{
+				return TEXT("Usage: Help <CommandName>\nUse 'ListCommands' to see available commands.");
+			}
+
+			FString CommandName = Args[0].ToLower();
+			FDebugCommand Command;
+
+			if (GetCommand(CommandName, Command))
+			{
+				FString Result;
+				Result += FString::Printf(TEXT("Command: %s\n"), *Command.Name);
+				Result += FString::Printf(TEXT("Category: %s\n"), *DebugCommands::GetCategoryName(Command.Category));
+				Result += FString::Printf(TEXT("Description: %s\n"), *Command.Description);
+				Result += FString::Printf(TEXT("Usage: Debug %s"), *Command.Usage);
+				return Result;
+			}
+
+			return FString::Printf(TEXT("Unknown command: %s"), *Args[0]);
+		}
+	);
+
+	// ShowStats - Show player statistics
+	RegisterNativeCommand(
+		TEXT("ShowStats"),
+		TEXT("Display current player statistics"),
+		EDebugCommandCategory::Info,
+		TEXT("ShowStats"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			FString Result = TEXT("Player Statistics:\n");
+			Result += TEXT("==================\n");
+
+			// Location
+			FVector Location = Character->GetActorLocation();
+			Result += FString::Printf(TEXT("Location: (%.1f, %.1f, %.1f)\n"), Location.X, Location.Y, Location.Z);
+
+			// Rotation
+			FRotator Rotation = Character->GetActorRotation();
+			Result += FString::Printf(TEXT("Rotation: (Pitch: %.1f, Yaw: %.1f, Roll: %.1f)\n"),
+				Rotation.Pitch, Rotation.Yaw, Rotation.Roll);
+
+			// Velocity
+			FVector Velocity = Character->GetVelocity();
+			Result += FString::Printf(TEXT("Velocity: %.1f (%.1f, %.1f, %.1f)\n"),
+				Velocity.Size(), Velocity.X, Velocity.Y, Velocity.Z);
+
+			// Movement mode
+			UCharacterMovementComponent* MovementComp = Character->GetCharacterMovement();
+			if (MovementComp)
+			{
+				FString MovementMode;
+				switch (MovementComp->MovementMode)
+				{
+				case MOVE_Walking: MovementMode = TEXT("Walking"); break;
+				case MOVE_Falling: MovementMode = TEXT("Falling"); break;
+				case MOVE_Flying: MovementMode = TEXT("Flying"); break;
+				case MOVE_Swimming: MovementMode = TEXT("Swimming"); break;
+				case MOVE_Custom: MovementMode = TEXT("Custom"); break;
+				default: MovementMode = TEXT("None"); break;
+				}
+				Result += FString::Printf(TEXT("Movement Mode: %s\n"), *MovementMode);
+				Result += FString::Printf(TEXT("Max Walk Speed: %.1f\n"), MovementComp->MaxWalkSpeed);
+			}
+
+			// Can be damaged
+			Result += FString::Printf(TEXT("Can Be Damaged: %s\n"), Character->CanBeDamaged() ? TEXT("Yes") : TEXT("No (God Mode)"));
+
+			// Try to get HP info via UFunction
+			UFunction* GetHPFunc = Character->FindFunction(TEXT("DebugGetHP"));
+			if (GetHPFunc)
+			{
+				struct { float CurrentHP; float MaxHP; } HPInfo = { 0.0f, 0.0f };
+				Character->ProcessEvent(GetHPFunc, &HPInfo);
+				Result += FString::Printf(TEXT("HP: %.1f / %.1f\n"), HPInfo.CurrentHP, HPInfo.MaxHP);
+			}
+
+			return Result;
+		}
+	);
+
+	// ShowPosition - Show only position info
+	RegisterNativeCommand(
+		TEXT("ShowPosition"),
+		TEXT("Display current position in copy-paste format"),
+		EDebugCommandCategory::Info,
+		TEXT("ShowPosition"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			FVector Location = Character->GetActorLocation();
+			return FString::Printf(TEXT("Position: %.1f %.1f %.1f\nUse: Debug Teleport %.1f %.1f %.1f"),
+				Location.X, Location.Y, Location.Z,
+				Location.X, Location.Y, Location.Z);
+		}
+	);
+}
+
+#endif // WITH_DEBUG_COMMANDS

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/MovementCommands.cpp
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/MovementCommands.cpp
@@ -1,0 +1,169 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#include "DebugCommandSubsystem.h"
+#include "DebugConsoleCommandsModule.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Character.h"
+#include "GameFramework/CharacterMovementComponent.h"
+#include "GameFramework/Pawn.h"
+
+#if WITH_DEBUG_COMMANDS
+
+namespace DebugCommands
+{
+	extern ACharacter* GetPlayerCharacter(UWorld* World);
+	extern APawn* GetPlayerPawn(UWorld* World);
+}
+
+void UDebugCommandSubsystem::RegisterMovementCommands()
+{
+	// Teleport - Move to coordinates
+	RegisterNativeCommand(
+		TEXT("Teleport"),
+		TEXT("Teleport player to specified coordinates"),
+		EDebugCommandCategory::Movement,
+		TEXT("Teleport X Y Z"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (Args.Num() < 3)
+			{
+				return TEXT("Usage: Teleport X Y Z");
+			}
+
+			APawn* Pawn = DebugCommands::GetPlayerPawn(World);
+			if (!Pawn)
+			{
+				return TEXT("No player pawn found");
+			}
+
+			float X = FCString::Atof(*Args[0]);
+			float Y = FCString::Atof(*Args[1]);
+			float Z = FCString::Atof(*Args[2]);
+
+			FVector NewLocation(X, Y, Z);
+			Pawn->SetActorLocation(NewLocation);
+
+			return FString::Printf(TEXT("Teleported to (%.1f, %.1f, %.1f)"), X, Y, Z);
+		}
+	);
+
+	// SetSpeed - Change movement speed multiplier
+	RegisterNativeCommand(
+		TEXT("SetSpeed"),
+		TEXT("Set movement speed multiplier"),
+		EDebugCommandCategory::Movement,
+		TEXT("SetSpeed <Multiplier>"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (Args.Num() < 1)
+			{
+				return TEXT("Usage: SetSpeed <Multiplier>");
+			}
+
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			UCharacterMovementComponent* MovementComp = Character->GetCharacterMovement();
+			if (!MovementComp)
+			{
+				return TEXT("No movement component found");
+			}
+
+			float Multiplier = FCString::Atof(*Args[0]);
+			if (Multiplier <= 0)
+			{
+				return TEXT("Multiplier must be greater than 0");
+			}
+
+			// Store original speed if not stored yet
+			static float OriginalMaxWalkSpeed = 0.0f;
+			if (OriginalMaxWalkSpeed == 0.0f)
+			{
+				OriginalMaxWalkSpeed = MovementComp->MaxWalkSpeed;
+			}
+
+			MovementComp->MaxWalkSpeed = OriginalMaxWalkSpeed * Multiplier;
+
+			return FString::Printf(TEXT("Speed multiplier set to %.2fx (MaxWalkSpeed: %.1f)"), Multiplier, MovementComp->MaxWalkSpeed);
+		}
+	);
+
+	// Fly - Toggle flying mode
+	RegisterNativeCommand(
+		TEXT("Fly"),
+		TEXT("Toggle flying mode"),
+		EDebugCommandCategory::Movement,
+		TEXT("Fly"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			UCharacterMovementComponent* MovementComp = Character->GetCharacterMovement();
+			if (!MovementComp)
+			{
+				return TEXT("No movement component found");
+			}
+
+			if (MovementComp->MovementMode == MOVE_Flying)
+			{
+				MovementComp->SetMovementMode(MOVE_Walking);
+				return TEXT("Flying disabled");
+			}
+			else
+			{
+				MovementComp->SetMovementMode(MOVE_Flying);
+				return TEXT("Flying enabled");
+			}
+		}
+	);
+
+	// Ghost - Toggle no-clip mode
+	RegisterNativeCommand(
+		TEXT("Ghost"),
+		TEXT("Toggle ghost (no-clip) mode"),
+		EDebugCommandCategory::Movement,
+		TEXT("Ghost"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			UCharacterMovementComponent* MovementComp = Character->GetCharacterMovement();
+			if (!MovementComp)
+			{
+				return TEXT("No movement component found");
+			}
+
+			// Toggle collision and flying
+			bool bIsGhost = !Character->GetActorEnableCollision();
+
+			Character->SetActorEnableCollision(!bIsGhost);
+
+			if (bIsGhost)
+			{
+				// Disable ghost mode
+				MovementComp->SetMovementMode(MOVE_Walking);
+				return TEXT("Ghost mode disabled");
+			}
+			else
+			{
+				// Enable ghost mode
+				MovementComp->SetMovementMode(MOVE_Flying);
+				return TEXT("Ghost mode enabled (no-clip + flying)");
+			}
+		}
+	);
+}
+
+#endif // WITH_DEBUG_COMMANDS

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/PlayerCommands.cpp
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/PlayerCommands.cpp
@@ -1,0 +1,135 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#include "DebugCommandSubsystem.h"
+#include "DebugConsoleCommandsModule.h"
+#include "Engine/World.h"
+#include "Engine/DamageEvents.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Character.h"
+#include "GameFramework/Pawn.h"
+
+#if WITH_DEBUG_COMMANDS
+
+namespace DebugCommands
+{
+	// Helper to get player character
+	ACharacter* GetPlayerCharacter(UWorld* World)
+	{
+		if (!World) return nullptr;
+
+		APlayerController* PC = World->GetFirstPlayerController();
+		if (!PC) return nullptr;
+
+		return PC->GetCharacter();
+	}
+
+	// Helper to get player pawn
+	APawn* GetPlayerPawn(UWorld* World)
+	{
+		if (!World) return nullptr;
+
+		APlayerController* PC = World->GetFirstPlayerController();
+		if (!PC) return nullptr;
+
+		return PC->GetPawn();
+	}
+}
+
+void UDebugCommandSubsystem::RegisterPlayerCommands()
+{
+	// God - Toggle invincibility
+	RegisterNativeCommand(
+		TEXT("God"),
+		TEXT("Toggle invincibility mode"),
+		EDebugCommandCategory::Player,
+		TEXT("God"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			// Toggle god mode using CanBeDamaged
+			bool bCurrentlyDamageable = Character->CanBeDamaged();
+			Character->SetCanBeDamaged(!bCurrentlyDamageable);
+
+			return bCurrentlyDamageable ? TEXT("God mode enabled") : TEXT("God mode disabled");
+		}
+	);
+
+	// Heal - Restore health
+	RegisterNativeCommand(
+		TEXT("Heal"),
+		TEXT("Restore player health. If no amount specified, fully heals."),
+		EDebugCommandCategory::Player,
+		TEXT("Heal [Amount]"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			// Try to find and call a Heal function via interface or direct call
+			// For now, we'll just report that the character was found
+			// The actual healing depends on the game's health system implementation
+
+			float Amount = 0.0f;
+			bool bFullHeal = (Args.Num() == 0);
+
+			if (!bFullHeal)
+			{
+				Amount = FCString::Atof(*Args[0]);
+				if (Amount <= 0)
+				{
+					return TEXT("Invalid heal amount");
+				}
+			}
+
+			// Call Blueprint-implementable heal through UFunction
+			UFunction* HealFunc = Character->FindFunction(TEXT("DebugHeal"));
+			if (HealFunc)
+			{
+				struct { float Amount; bool bFullHeal; } Params = { Amount, bFullHeal };
+				Character->ProcessEvent(HealFunc, &Params);
+				return bFullHeal ? TEXT("Fully healed") : FString::Printf(TEXT("Healed for %.1f"), Amount);
+			}
+
+			return bFullHeal ? TEXT("Full heal requested (implement DebugHeal function)")
+			                 : FString::Printf(TEXT("Heal %.1f requested (implement DebugHeal function)"), Amount);
+		}
+	);
+
+	// Kill - Kill player
+	RegisterNativeCommand(
+		TEXT("Kill"),
+		TEXT("Kill the player character"),
+		EDebugCommandCategory::Player,
+		TEXT("Kill"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			ACharacter* Character = DebugCommands::GetPlayerCharacter(World);
+			if (!Character)
+			{
+				return TEXT("No player character found");
+			}
+
+			// Try to call a Kill/Die function
+			UFunction* KillFunc = Character->FindFunction(TEXT("DebugKill"));
+			if (KillFunc)
+			{
+				Character->ProcessEvent(KillFunc, nullptr);
+				return TEXT("Player killed");
+			}
+
+			// Alternative: Try TakeDamage with large amount
+			Character->TakeDamage(999999.0f, FDamageEvent(), nullptr, nullptr);
+			return TEXT("Player killed (via TakeDamage)");
+		}
+	);
+}
+
+#endif // WITH_DEBUG_COMMANDS

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/SpawnCommands.cpp
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/SpawnCommands.cpp
@@ -1,0 +1,205 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#include "DebugCommandSubsystem.h"
+#include "DebugConsoleCommandsModule.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Character.h"
+#include "UObject/ConstructorHelpers.h"
+#include "Engine/Blueprint.h"
+
+#if WITH_DEBUG_COMMANDS
+
+namespace DebugCommands
+{
+	extern ACharacter* GetPlayerCharacter(UWorld* World);
+	extern APawn* GetPlayerPawn(UWorld* World);
+}
+
+void UDebugCommandSubsystem::RegisterSpawnCommands()
+{
+	// SpawnActor - Spawn an actor by class name
+	RegisterNativeCommand(
+		TEXT("SpawnActor"),
+		TEXT("Spawn an actor at player location or specified coordinates"),
+		EDebugCommandCategory::Spawn,
+		TEXT("SpawnActor <BlueprintPath> [X Y Z]"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (Args.Num() < 1)
+			{
+				return TEXT("Usage: SpawnActor <BlueprintPath> [X Y Z]");
+			}
+
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			// Get spawn location
+			FVector SpawnLocation;
+			if (Args.Num() >= 4)
+			{
+				SpawnLocation.X = FCString::Atof(*Args[1]);
+				SpawnLocation.Y = FCString::Atof(*Args[2]);
+				SpawnLocation.Z = FCString::Atof(*Args[3]);
+			}
+			else
+			{
+				// Spawn in front of player
+				APawn* PlayerPawn = DebugCommands::GetPlayerPawn(World);
+				if (PlayerPawn)
+				{
+					SpawnLocation = PlayerPawn->GetActorLocation() + PlayerPawn->GetActorForwardVector() * 300.0f;
+				}
+				else
+				{
+					SpawnLocation = FVector::ZeroVector;
+				}
+			}
+
+			// Try to load the blueprint
+			FString BlueprintPath = Args[0];
+
+			// Add Blueprint prefix if not present
+			if (!BlueprintPath.Contains(TEXT(".")))
+			{
+				BlueprintPath = FString::Printf(TEXT("Blueprint'%s.%s'"),
+					*BlueprintPath,
+					*FPaths::GetBaseFilename(BlueprintPath));
+			}
+
+			UClass* ActorClass = nullptr;
+
+			// Try to load as Blueprint
+			UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *BlueprintPath);
+			if (Blueprint && Blueprint->GeneratedClass)
+			{
+				ActorClass = Blueprint->GeneratedClass;
+			}
+			else
+			{
+				// Try to find C++ class
+				ActorClass = FindObject<UClass>(nullptr, *Args[0]);
+			}
+
+			if (!ActorClass)
+			{
+				return FString::Printf(TEXT("Could not find class: %s"), *Args[0]);
+			}
+
+			// Spawn the actor
+			FActorSpawnParameters SpawnParams;
+			SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
+
+			AActor* SpawnedActor = World->SpawnActor<AActor>(ActorClass, SpawnLocation, FRotator::ZeroRotator, SpawnParams);
+
+			if (SpawnedActor)
+			{
+				return FString::Printf(TEXT("Spawned %s at (%.1f, %.1f, %.1f)"),
+					*ActorClass->GetName(),
+					SpawnLocation.X, SpawnLocation.Y, SpawnLocation.Z);
+			}
+			else
+			{
+				return FString::Printf(TEXT("Failed to spawn %s"), *ActorClass->GetName());
+			}
+		}
+	);
+
+	// SpawnEnemy - Spawn enemy by type name
+	RegisterNativeCommand(
+		TEXT("SpawnEnemy"),
+		TEXT("Spawn enemy actor(s) near player"),
+		EDebugCommandCategory::Spawn,
+		TEXT("SpawnEnemy <EnemyType> [Count]"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (Args.Num() < 1)
+			{
+				return TEXT("Usage: SpawnEnemy <EnemyType> [Count]");
+			}
+
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			int32 Count = 1;
+			if (Args.Num() >= 2)
+			{
+				Count = FCString::Atoi(*Args[1]);
+				if (Count <= 0) Count = 1;
+				if (Count > 50) Count = 50; // Safety limit
+			}
+
+			// Get player location for spawn reference
+			APawn* PlayerPawn = DebugCommands::GetPlayerPawn(World);
+			FVector BaseLocation = PlayerPawn ? PlayerPawn->GetActorLocation() : FVector::ZeroVector;
+			FVector ForwardVector = PlayerPawn ? PlayerPawn->GetActorForwardVector() : FVector::ForwardVector;
+
+			// Try to load the enemy blueprint
+			FString EnemyType = Args[0];
+			FString BlueprintPath;
+
+			// Check common enemy blueprint paths
+			TArray<FString> SearchPaths = {
+				FString::Printf(TEXT("/Game/Variant_Combat/Blueprints/%s.%s"), *EnemyType, *EnemyType),
+				FString::Printf(TEXT("/Game/Variant_Combat/Blueprints/Enemies/%s.%s"), *EnemyType, *EnemyType),
+				FString::Printf(TEXT("/Game/Blueprints/%s.%s"), *EnemyType, *EnemyType),
+				FString::Printf(TEXT("/Game/Blueprints/Enemies/%s.%s"), *EnemyType, *EnemyType),
+			};
+
+			UClass* EnemyClass = nullptr;
+
+			for (const FString& Path : SearchPaths)
+			{
+				UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *Path);
+				if (Blueprint && Blueprint->GeneratedClass)
+				{
+					EnemyClass = Blueprint->GeneratedClass;
+					break;
+				}
+			}
+
+			// Try direct path if provided
+			if (!EnemyClass)
+			{
+				UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *EnemyType);
+				if (Blueprint && Blueprint->GeneratedClass)
+				{
+					EnemyClass = Blueprint->GeneratedClass;
+				}
+			}
+
+			if (!EnemyClass)
+			{
+				return FString::Printf(TEXT("Could not find enemy type: %s"), *EnemyType);
+			}
+
+			// Spawn enemies
+			int32 SpawnedCount = 0;
+			FActorSpawnParameters SpawnParams;
+			SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
+
+			for (int32 i = 0; i < Count; ++i)
+			{
+				// Calculate spawn position in a spread pattern
+				float Angle = (float)i / (float)Count * 360.0f;
+				float Distance = 400.0f + (i / 8) * 200.0f;
+				FVector Offset = ForwardVector.RotateAngleAxis(Angle, FVector::UpVector) * Distance;
+				FVector SpawnLocation = BaseLocation + ForwardVector * 300.0f + Offset;
+
+				AActor* SpawnedActor = World->SpawnActor<AActor>(EnemyClass, SpawnLocation, FRotator::ZeroRotator, SpawnParams);
+				if (SpawnedActor)
+				{
+					SpawnedCount++;
+				}
+			}
+
+			return FString::Printf(TEXT("Spawned %d/%d %s"), SpawnedCount, Count, *EnemyType);
+		}
+	);
+}
+
+#endif // WITH_DEBUG_COMMANDS

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/SystemCommands.cpp
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/Commands/SystemCommands.cpp
@@ -1,0 +1,166 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#include "DebugCommandSubsystem.h"
+#include "DebugConsoleCommandsModule.h"
+#include "Engine/World.h"
+#include "GameFramework/WorldSettings.h"
+#include "Kismet/GameplayStatics.h"
+
+#if WITH_DEBUG_COMMANDS
+
+void UDebugCommandSubsystem::RegisterSystemCommands()
+{
+	// SlowMo - Change game speed
+	RegisterNativeCommand(
+		TEXT("SlowMo"),
+		TEXT("Set game time dilation (slow motion)"),
+		EDebugCommandCategory::System,
+		TEXT("SlowMo <Scale> (0.1 - 2.0)"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (Args.Num() < 1)
+			{
+				return TEXT("Usage: SlowMo <Scale> (0.1 - 2.0)");
+			}
+
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			float Scale = FCString::Atof(*Args[0]);
+			Scale = FMath::Clamp(Scale, 0.1f, 2.0f);
+
+			AWorldSettings* WorldSettings = World->GetWorldSettings();
+			if (WorldSettings)
+			{
+				WorldSettings->TimeDilation = Scale;
+				return FString::Printf(TEXT("Time dilation set to %.2fx"), Scale);
+			}
+
+			return TEXT("Failed to set time dilation");
+		}
+	);
+
+	// Pause - Toggle pause
+	RegisterNativeCommand(
+		TEXT("Pause"),
+		TEXT("Toggle game pause"),
+		EDebugCommandCategory::System,
+		TEXT("Pause"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			APlayerController* PC = World->GetFirstPlayerController();
+			if (!PC)
+			{
+				return TEXT("No player controller found");
+			}
+
+			bool bIsPaused = UGameplayStatics::IsGamePaused(World);
+			UGameplayStatics::SetGamePaused(World, !bIsPaused);
+
+			return bIsPaused ? TEXT("Game unpaused") : TEXT("Game paused");
+		}
+	);
+
+	// RestartLevel - Restart current level
+	RegisterNativeCommand(
+		TEXT("RestartLevel"),
+		TEXT("Restart the current level"),
+		EDebugCommandCategory::System,
+		TEXT("RestartLevel"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			FString CurrentLevel = World->GetMapName();
+			UGameplayStatics::OpenLevel(World, FName(*CurrentLevel));
+
+			return FString::Printf(TEXT("Restarting level: %s"), *CurrentLevel);
+		}
+	);
+
+	// OpenLevel - Open a specific level
+	RegisterNativeCommand(
+		TEXT("OpenLevel"),
+		TEXT("Open a specific level by name"),
+		EDebugCommandCategory::System,
+		TEXT("OpenLevel <LevelName>"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (Args.Num() < 1)
+			{
+				return TEXT("Usage: OpenLevel <LevelName>");
+			}
+
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			FString LevelName = Args[0];
+			UGameplayStatics::OpenLevel(World, FName(*LevelName));
+
+			return FString::Printf(TEXT("Opening level: %s"), *LevelName);
+		}
+	);
+
+	// ShowFPS - Toggle FPS display
+	RegisterNativeCommand(
+		TEXT("ShowFPS"),
+		TEXT("Toggle FPS display"),
+		EDebugCommandCategory::System,
+		TEXT("ShowFPS"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			// Use console command to toggle stat fps
+			APlayerController* PC = World->GetFirstPlayerController();
+			if (PC)
+			{
+				PC->ConsoleCommand(TEXT("stat fps"));
+				return TEXT("FPS display toggled");
+			}
+
+			return TEXT("No player controller found");
+		}
+	);
+
+	// ShowStats - Toggle stat unit display
+	RegisterNativeCommand(
+		TEXT("ShowUnit"),
+		TEXT("Toggle stat unit display (frame time, game time, etc.)"),
+		EDebugCommandCategory::System,
+		TEXT("ShowUnit"),
+		[](const TArray<FString>& Args, UWorld* World) -> FString
+		{
+			if (!World)
+			{
+				return TEXT("No world found");
+			}
+
+			APlayerController* PC = World->GetFirstPlayerController();
+			if (PC)
+			{
+				PC->ConsoleCommand(TEXT("stat unit"));
+				return TEXT("Unit stats display toggled");
+			}
+
+			return TEXT("No player controller found");
+		}
+	);
+}
+
+#endif // WITH_DEBUG_COMMANDS

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/DebugCommandBlueprintLibrary.cpp
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/DebugCommandBlueprintLibrary.cpp
@@ -1,0 +1,58 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#include "DebugCommandBlueprintLibrary.h"
+#include "DebugCommandSubsystem.h"
+#include "Engine/World.h"
+#include "Engine/GameInstance.h"
+
+bool UDebugCommandBlueprintLibrary::ExecuteDebugCommand(const UObject* WorldContextObject, const FString& CommandLine, FString& OutResult)
+{
+#if WITH_DEBUG_COMMANDS
+	UDebugCommandSubsystem* Subsystem = UDebugCommandSubsystem::Get(WorldContextObject);
+	if (Subsystem)
+	{
+		return Subsystem->ExecuteCommand(CommandLine, OutResult);
+	}
+	OutResult = TEXT("Debug command subsystem not available");
+	return false;
+#else
+	OutResult = TEXT("Debug commands are not available in this build");
+	return false;
+#endif
+}
+
+bool UDebugCommandBlueprintLibrary::IsDebugCommandsEnabled()
+{
+#if WITH_DEBUG_COMMANDS
+	return true;
+#else
+	return false;
+#endif
+}
+
+TArray<FDebugCommand> UDebugCommandBlueprintLibrary::GetAllDebugCommands(const UObject* WorldContextObject)
+{
+#if WITH_DEBUG_COMMANDS
+	UDebugCommandSubsystem* Subsystem = UDebugCommandSubsystem::Get(WorldContextObject);
+	if (Subsystem)
+	{
+		return Subsystem->GetAllCommands();
+	}
+#endif
+	return TArray<FDebugCommand>();
+}
+
+FString UDebugCommandBlueprintLibrary::GetCategoryDisplayName(EDebugCommandCategory Category)
+{
+	switch (Category)
+	{
+	case EDebugCommandCategory::Player:   return TEXT("Player");
+	case EDebugCommandCategory::Movement: return TEXT("Movement");
+	case EDebugCommandCategory::Combat:   return TEXT("Combat");
+	case EDebugCommandCategory::Spawn:    return TEXT("Spawn");
+	case EDebugCommandCategory::System:   return TEXT("System");
+	case EDebugCommandCategory::Info:     return TEXT("Info");
+	case EDebugCommandCategory::Custom:   return TEXT("Custom");
+	default: return TEXT("Unknown");
+	}
+}

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/DebugCommandSubsystem.cpp
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/DebugCommandSubsystem.cpp
@@ -1,0 +1,267 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#include "DebugCommandSubsystem.h"
+#include "DebugConsoleCommandsModule.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Character.h"
+#include "GameFramework/CharacterMovementComponent.h"
+#include "Engine/Engine.h"
+#include "HAL/IConsoleManager.h"
+
+UDebugCommandSubsystem* UDebugCommandSubsystem::Get(const UObject* WorldContextObject)
+{
+	if (!WorldContextObject)
+	{
+		return nullptr;
+	}
+
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::ReturnNull);
+	if (!World)
+	{
+		return nullptr;
+	}
+
+	UGameInstance* GameInstance = World->GetGameInstance();
+	if (!GameInstance)
+	{
+		return nullptr;
+	}
+
+	return GameInstance->GetSubsystem<UDebugCommandSubsystem>();
+}
+
+void UDebugCommandSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+#if WITH_DEBUG_COMMANDS
+	UE_LOG(LogDebugCommands, Log, TEXT("DebugCommandSubsystem initializing..."));
+
+	// Register console command
+	ConsoleCommand = IConsoleManager::Get().RegisterConsoleCommand(
+		TEXT("Debug"),
+		TEXT("Execute a debug command. Use 'Debug ListCommands' to see available commands."),
+		FConsoleCommandWithWorldArgsAndOutputDeviceDelegate::CreateLambda(
+			[this](const TArray<FString>& Args, UWorld* World, FOutputDevice& Ar)
+			{
+				if (Args.Num() == 0)
+				{
+					Ar.Log(TEXT("Usage: Debug <command> [args...]"));
+					Ar.Log(TEXT("Use 'Debug ListCommands' to see available commands."));
+					return;
+				}
+
+				FString CommandLine = FString::Join(Args, TEXT(" "));
+				FString Result;
+				if (ExecuteCommand(CommandLine, Result))
+				{
+					Ar.Log(*Result);
+				}
+				else
+				{
+					Ar.Log(*FString::Printf(TEXT("Unknown command: %s. Use 'Debug ListCommands' for available commands."), *Args[0]));
+				}
+			}
+		),
+		ECVF_Cheat
+	);
+
+	// Register built-in commands
+	RegisterBuiltInCommands();
+
+	UE_LOG(LogDebugCommands, Log, TEXT("DebugCommandSubsystem initialized with %d commands"), Commands.Num());
+#endif
+}
+
+void UDebugCommandSubsystem::Deinitialize()
+{
+#if WITH_DEBUG_COMMANDS
+	// Unregister console command
+	if (ConsoleCommand)
+	{
+		IConsoleManager::Get().UnregisterConsoleObject(ConsoleCommand);
+		ConsoleCommand = nullptr;
+	}
+
+	Commands.Empty();
+	UE_LOG(LogDebugCommands, Log, TEXT("DebugCommandSubsystem deinitialized"));
+#endif
+
+	Super::Deinitialize();
+}
+
+bool UDebugCommandSubsystem::ShouldCreateSubsystem(UObject* Outer) const
+{
+#if WITH_DEBUG_COMMANDS
+	return true;
+#else
+	return false;
+#endif
+}
+
+void UDebugCommandSubsystem::RegisterCommand(
+	const FString& Name,
+	const FString& Description,
+	EDebugCommandCategory Category,
+	const FString& Usage,
+	const FDebugCommandDelegate& ExecuteDelegate)
+{
+#if WITH_DEBUG_COMMANDS
+	FDebugCommand Command;
+	Command.Name = Name;
+	Command.Description = Description;
+	Command.Category = Category;
+	Command.Usage = Usage;
+	Command.ExecuteDelegate = ExecuteDelegate;
+
+	Commands.Add(Name.ToLower(), Command);
+	UE_LOG(LogDebugCommands, Verbose, TEXT("Registered command: %s"), *Name);
+#endif
+}
+
+void UDebugCommandSubsystem::RegisterNativeCommand(
+	const FString& Name,
+	const FString& Description,
+	EDebugCommandCategory Category,
+	const FString& Usage,
+	TFunction<FString(const TArray<FString>&, UWorld*)> ExecuteFunc)
+{
+#if WITH_DEBUG_COMMANDS
+	FDebugCommand Command(Name, Description, Category, Usage, ExecuteFunc);
+	Commands.Add(Name.ToLower(), Command);
+	UE_LOG(LogDebugCommands, Verbose, TEXT("Registered native command: %s"), *Name);
+#endif
+}
+
+void UDebugCommandSubsystem::UnregisterCommand(const FString& Name)
+{
+#if WITH_DEBUG_COMMANDS
+	Commands.Remove(Name.ToLower());
+	UE_LOG(LogDebugCommands, Verbose, TEXT("Unregistered command: %s"), *Name);
+#endif
+}
+
+bool UDebugCommandSubsystem::ExecuteCommand(const FString& CommandLine, FString& OutResult)
+{
+#if WITH_DEBUG_COMMANDS
+	// Parse command line
+	TArray<FString> Tokens;
+	CommandLine.ParseIntoArrayWS(Tokens);
+
+	if (Tokens.Num() == 0)
+	{
+		OutResult = TEXT("No command specified");
+		return false;
+	}
+
+	FString CommandName = Tokens[0].ToLower();
+	TArray<FString> Args;
+	for (int32 i = 1; i < Tokens.Num(); ++i)
+	{
+		Args.Add(Tokens[i]);
+	}
+
+	// Find and execute command
+	FDebugCommand* Command = Commands.Find(CommandName);
+	if (!Command)
+	{
+		OutResult = FString::Printf(TEXT("Unknown command: %s"), *Tokens[0]);
+		return false;
+	}
+
+	// Get world
+	UWorld* World = GetGameInstance()->GetWorld();
+
+	// Execute native command
+	if (Command->NativeExecute)
+	{
+		OutResult = Command->NativeExecute(Args, World);
+		return true;
+	}
+
+	// Execute delegate command
+	if (Command->ExecuteDelegate.IsBound())
+	{
+		Command->ExecuteDelegate.Execute(Args, OutResult);
+		return true;
+	}
+
+	OutResult = TEXT("Command has no execution handler");
+	return false;
+#else
+	OutResult = TEXT("Debug commands are not available in this build");
+	return false;
+#endif
+}
+
+TArray<FDebugCommand> UDebugCommandSubsystem::GetAllCommands() const
+{
+	TArray<FDebugCommand> Result;
+#if WITH_DEBUG_COMMANDS
+	Commands.GenerateValueArray(Result);
+#endif
+	return Result;
+}
+
+TArray<FDebugCommand> UDebugCommandSubsystem::GetCommandsByCategory(EDebugCommandCategory Category) const
+{
+	TArray<FDebugCommand> Result;
+#if WITH_DEBUG_COMMANDS
+	for (const auto& Pair : Commands)
+	{
+		if (Pair.Value.Category == Category)
+		{
+			Result.Add(Pair.Value);
+		}
+	}
+#endif
+	return Result;
+}
+
+bool UDebugCommandSubsystem::GetCommand(const FString& Name, FDebugCommand& OutCommand) const
+{
+#if WITH_DEBUG_COMMANDS
+	const FDebugCommand* Command = Commands.Find(Name.ToLower());
+	if (Command)
+	{
+		OutCommand = *Command;
+		return true;
+	}
+#endif
+	return false;
+}
+
+bool UDebugCommandSubsystem::AreDebugCommandsEnabled()
+{
+#if WITH_DEBUG_COMMANDS
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool UDebugCommandSubsystem::ProcessConsoleCommand(const TCHAR* Cmd, FOutputDevice& Ar, UWorld* World)
+{
+#if WITH_DEBUG_COMMANDS
+	FString Result;
+	if (ExecuteCommand(Cmd, Result))
+	{
+		Ar.Log(*Result);
+		return true;
+	}
+#endif
+	return false;
+}
+
+void UDebugCommandSubsystem::RegisterBuiltInCommands()
+{
+#if WITH_DEBUG_COMMANDS
+	RegisterPlayerCommands();
+	RegisterMovementCommands();
+	RegisterCombatCommands();
+	RegisterSpawnCommands();
+	RegisterSystemCommands();
+	RegisterInfoCommands();
+#endif
+}

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/DebugConsoleCommandsModule.cpp
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Private/DebugConsoleCommandsModule.cpp
@@ -1,0 +1,25 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#include "DebugConsoleCommandsModule.h"
+
+#define LOCTEXT_NAMESPACE "FDebugConsoleCommandsModule"
+
+DEFINE_LOG_CATEGORY(LogDebugCommands);
+
+void FDebugConsoleCommandsModule::StartupModule()
+{
+#if WITH_DEBUG_COMMANDS
+	UE_LOG(LogDebugCommands, Log, TEXT("DebugConsoleCommands module started"));
+#endif
+}
+
+void FDebugConsoleCommandsModule::ShutdownModule()
+{
+#if WITH_DEBUG_COMMANDS
+	UE_LOG(LogDebugCommands, Log, TEXT("DebugConsoleCommands module shutdown"));
+#endif
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FDebugConsoleCommandsModule, DebugConsoleCommands)

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Public/DebugCommand.h
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Public/DebugCommand.h
@@ -1,0 +1,73 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "DebugCommand.generated.h"
+
+/**
+ * Debug command category
+ */
+UENUM(BlueprintType)
+enum class EDebugCommandCategory : uint8
+{
+	Player		UMETA(DisplayName = "Player"),
+	Movement	UMETA(DisplayName = "Movement"),
+	Combat		UMETA(DisplayName = "Combat"),
+	Spawn		UMETA(DisplayName = "Spawn"),
+	System		UMETA(DisplayName = "System"),
+	Info		UMETA(DisplayName = "Info"),
+	Custom		UMETA(DisplayName = "Custom")
+};
+
+/**
+ * Delegate for command execution
+ */
+DECLARE_DYNAMIC_DELEGATE_TwoParams(FDebugCommandDelegate, const TArray<FString>&, Args, FString&, OutResult);
+
+/**
+ * Debug command structure
+ */
+USTRUCT(BlueprintType)
+struct DEBUGCONSOLECOMMANDS_API FDebugCommand
+{
+	GENERATED_BODY()
+
+	/** Command name (case-insensitive) */
+	UPROPERTY(BlueprintReadOnly, Category = "Debug Command")
+	FString Name;
+
+	/** Command description */
+	UPROPERTY(BlueprintReadOnly, Category = "Debug Command")
+	FString Description;
+
+	/** Command category */
+	UPROPERTY(BlueprintReadOnly, Category = "Debug Command")
+	EDebugCommandCategory Category = EDebugCommandCategory::Custom;
+
+	/** Usage syntax */
+	UPROPERTY(BlueprintReadOnly, Category = "Debug Command")
+	FString Usage;
+
+	/** Execution delegate */
+	FDebugCommandDelegate ExecuteDelegate;
+
+	/** Native execution function (for C++ commands) */
+	TFunction<FString(const TArray<FString>&, UWorld*)> NativeExecute;
+
+	FDebugCommand() = default;
+
+	FDebugCommand(
+		const FString& InName,
+		const FString& InDescription,
+		EDebugCommandCategory InCategory,
+		const FString& InUsage,
+		TFunction<FString(const TArray<FString>&, UWorld*)> InNativeExecute)
+		: Name(InName)
+		, Description(InDescription)
+		, Category(InCategory)
+		, Usage(InUsage)
+		, NativeExecute(InNativeExecute)
+	{
+	}
+};

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Public/DebugCommandBlueprintLibrary.h
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Public/DebugCommandBlueprintLibrary.h
@@ -1,0 +1,46 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+#include "DebugCommand.h"
+#include "DebugCommandBlueprintLibrary.generated.h"
+
+/**
+ * Blueprint function library for debug commands
+ */
+UCLASS()
+class DEBUGCONSOLECOMMANDS_API UDebugCommandBlueprintLibrary : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+public:
+	/**
+	 * Execute a debug command
+	 * @param WorldContextObject World context
+	 * @param CommandLine Full command line to execute
+	 * @param OutResult Result message from command
+	 * @return True if command was found and executed
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Debug Commands", meta = (WorldContext = "WorldContextObject"))
+	static bool ExecuteDebugCommand(const UObject* WorldContextObject, const FString& CommandLine, FString& OutResult);
+
+	/**
+	 * Check if debug commands are enabled in this build
+	 */
+	UFUNCTION(BlueprintPure, Category = "Debug Commands")
+	static bool IsDebugCommandsEnabled();
+
+	/**
+	 * Get all available debug commands
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Debug Commands", meta = (WorldContext = "WorldContextObject"))
+	static TArray<FDebugCommand> GetAllDebugCommands(const UObject* WorldContextObject);
+
+	/**
+	 * Get the category display name
+	 */
+	UFUNCTION(BlueprintPure, Category = "Debug Commands")
+	static FString GetCategoryDisplayName(EDebugCommandCategory Category);
+};

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Public/DebugCommandSubsystem.h
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Public/DebugCommandSubsystem.h
@@ -1,0 +1,120 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "DebugCommand.h"
+#include "DebugCommandSubsystem.generated.h"
+
+/**
+ * Subsystem for managing debug console commands
+ */
+UCLASS()
+class DEBUGCONSOLECOMMANDS_API UDebugCommandSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	/** Get the subsystem from world context */
+	UFUNCTION(BlueprintPure, Category = "Debug Commands", meta = (WorldContext = "WorldContextObject"))
+	static UDebugCommandSubsystem* Get(const UObject* WorldContextObject);
+
+	//~ Begin USubsystem Interface
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
+	//~ End USubsystem Interface
+
+	/**
+	 * Register a command with native C++ execution
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Debug Commands")
+	void RegisterCommand(
+		const FString& Name,
+		const FString& Description,
+		EDebugCommandCategory Category,
+		const FString& Usage,
+		const FDebugCommandDelegate& ExecuteDelegate);
+
+	/**
+	 * Register a native C++ command
+	 */
+	void RegisterNativeCommand(
+		const FString& Name,
+		const FString& Description,
+		EDebugCommandCategory Category,
+		const FString& Usage,
+		TFunction<FString(const TArray<FString>&, UWorld*)> ExecuteFunc);
+
+	/**
+	 * Unregister a command
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Debug Commands")
+	void UnregisterCommand(const FString& Name);
+
+	/**
+	 * Execute a command by command line
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Debug Commands")
+	bool ExecuteCommand(const FString& CommandLine, FString& OutResult);
+
+	/**
+	 * Get all registered commands
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Debug Commands")
+	TArray<FDebugCommand> GetAllCommands() const;
+
+	/**
+	 * Get commands by category
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Debug Commands")
+	TArray<FDebugCommand> GetCommandsByCategory(EDebugCommandCategory Category) const;
+
+	/**
+	 * Get a command by name
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Debug Commands")
+	bool GetCommand(const FString& Name, FDebugCommand& OutCommand) const;
+
+	/**
+	 * Check if debug commands are enabled
+	 */
+	UFUNCTION(BlueprintPure, Category = "Debug Commands")
+	static bool AreDebugCommandsEnabled();
+
+	/**
+	 * Process console command (called from CheatManager or Exec)
+	 */
+	bool ProcessConsoleCommand(const TCHAR* Cmd, FOutputDevice& Ar, UWorld* World);
+
+protected:
+	/** Register all built-in commands */
+	void RegisterBuiltInCommands();
+
+	/** Register player commands */
+	void RegisterPlayerCommands();
+
+	/** Register movement commands */
+	void RegisterMovementCommands();
+
+	/** Register combat commands */
+	void RegisterCombatCommands();
+
+	/** Register spawn commands */
+	void RegisterSpawnCommands();
+
+	/** Register system commands */
+	void RegisterSystemCommands();
+
+	/** Register info/help commands */
+	void RegisterInfoCommands();
+
+private:
+	/** Registered commands */
+	UPROPERTY()
+	TMap<FString, FDebugCommand> Commands;
+
+	/** Console command handle */
+	IConsoleObject* ConsoleCommand = nullptr;
+};

--- a/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Public/DebugConsoleCommandsModule.h
+++ b/Plugins/DebugConsoleCommands/Source/DebugConsoleCommands/Public/DebugConsoleCommandsModule.h
@@ -1,0 +1,16 @@
+// Copyright Antigravity. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogDebugCommands, Log, All);
+
+class FDebugConsoleCommandsModule : public IModuleInterface
+{
+public:
+	/** IModuleInterface implementation */
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};

--- a/docs/specs/debug-console-commands.md
+++ b/docs/specs/debug-console-commands.md
@@ -1,0 +1,272 @@
+# Debug Console Commands Plugin
+
+## 概要
+
+開発者向けのコンソールコマンド集プラグイン。ゲームプレイのテストやデバッグを高速化するためのチートコマンドを提供する。
+
+## 基本情報
+
+| 項目 | 値 |
+|------|-----|
+| プラグイン名 | DebugConsoleCommands |
+| モジュールタイプ | Runtime (DeveloperOnly) |
+| ロードフェーズ | Default |
+| 対象ビルド | Editor, Development のみ |
+
+## 要件
+
+### 必須要件
+
+1. **コマンド登録システム**
+   - コンソールコマンドを一元管理するサブシステム
+   - コマンドの動的な登録・解除が可能
+   - カテゴリ別のコマンド整理
+
+2. **基本コマンドセット**
+   - `God` - 無敵モード切替
+   - `Heal [Amount]` - HP回復（引数省略で全回復）
+   - `Kill` - プレイヤーを即死させる
+   - `Teleport X Y Z` - 指定座標へテレポート
+   - `SpawnActor <ClassName> [X Y Z]` - アクターをスポーン
+   - `SetSpeed <Multiplier>` - 移動速度倍率変更
+   - `SlowMo <Scale>` - ゲーム速度変更（0.1〜2.0）
+   - `Fly` - 飛行モード切替
+   - `Ghost` - ノークリップモード切替
+
+3. **戦闘デバッグコマンド**（Variant_Combat連携）
+   - `SetHP <Amount>` - HP設定
+   - `SetMaxHP <Amount>` - 最大HP設定
+   - `SpawnEnemy <EnemyType> [Count]` - 敵スポーン
+   - `KillAllEnemies` - 全敵を即死
+   - `ToggleAI` - AI有効/無効切替
+
+4. **情報表示コマンド**
+   - `ShowStats` - 現在のプレイヤーステータス表示
+   - `ListCommands [Category]` - 利用可能なコマンド一覧
+   - `Help <CommandName>` - コマンドのヘルプ表示
+
+### オプション要件
+
+1. **コマンド履歴**
+   - 直近のコマンド履歴を保持
+   - 上下キーで履歴呼び出し（UE標準機能を活用）
+
+2. **コマンドエイリアス**
+   - 短縮コマンドの定義（例: `tp` = `Teleport`）
+
+3. **Blueprint拡張**
+   - Blueprintからカスタムコマンドを追加可能
+
+## アーキテクチャ
+
+### クラス構成
+
+```
+UDebugCommandSubsystem (UGameInstanceSubsystem)
+├── RegisterCommand()      # コマンド登録
+├── UnregisterCommand()    # コマンド解除
+├── ExecuteCommand()       # コマンド実行
+└── GetCommandList()       # コマンド一覧取得
+
+FDebugCommand (構造体)
+├── Name                   # コマンド名
+├── Description            # 説明
+├── Category              # カテゴリ
+├── Usage                 # 使用方法
+└── ExecuteDelegate       # 実行デリゲート
+
+UDebugCommandBlueprintLibrary (UBlueprintFunctionLibrary)
+├── ExecuteDebugCommand() # BPからコマンド実行
+└── IsDebugCommandsEnabled() # 有効判定
+```
+
+### モジュール構成
+
+```
+DebugConsoleCommands/
+├── DebugConsoleCommands.uplugin
+└── Source/
+    └── DebugConsoleCommands/
+        ├── DebugConsoleCommands.Build.cs
+        ├── Public/
+        │   ├── DebugConsoleCommandsModule.h
+        │   ├── DebugCommandSubsystem.h
+        │   ├── DebugCommand.h
+        │   └── DebugCommandBlueprintLibrary.h
+        └── Private/
+            ├── DebugConsoleCommandsModule.cpp
+            ├── DebugCommandSubsystem.cpp
+            ├── DebugCommandBlueprintLibrary.cpp
+            └── Commands/
+                ├── PlayerCommands.cpp      # God, Heal, Kill等
+                ├── MovementCommands.cpp    # Teleport, Fly, Ghost等
+                ├── SpawnCommands.cpp       # SpawnActor, SpawnEnemy等
+                ├── CombatCommands.cpp      # SetHP, KillAllEnemies等
+                └── SystemCommands.cpp      # SlowMo, ShowStats等
+```
+
+## インターフェース
+
+### コマンド登録
+
+```cpp
+// コマンドの登録
+UFUNCTION(BlueprintCallable, Category="Debug Commands")
+void RegisterCommand(
+    const FString& Name,
+    const FString& Description,
+    const FString& Category,
+    const FString& Usage,
+    const FDebugCommandDelegate& ExecuteDelegate
+);
+
+// デリゲート定義
+DECLARE_DYNAMIC_DELEGATE_TwoParams(
+    FDebugCommandDelegate,
+    const TArray<FString>&, Args,
+    FString&, OutResult
+);
+```
+
+### コマンド実行
+
+```cpp
+// コンソールからの実行（Execコマンド経由）
+static bool Exec(UWorld* World, const TCHAR* Cmd, FOutputDevice& Ar);
+
+// プログラムからの実行
+UFUNCTION(BlueprintCallable, Category="Debug Commands")
+bool ExecuteCommand(const FString& CommandLine, FString& OutResult);
+```
+
+## 振る舞い
+
+### 正常系
+
+1. **コマンド実行成功**
+   - コマンドが認識され、正常に実行される
+   - 結果メッセージがコンソールに出力される
+   - 例: `God mode enabled`
+
+2. **引数付きコマンド**
+   - 引数が正しくパースされる
+   - 省略可能な引数はデフォルト値を使用
+   - 例: `Heal` → 全回復、`Heal 50` → 50回復
+
+### エラー時
+
+1. **コマンド未認識**
+   - `Unknown debug command: <command>. Type 'ListCommands' for available commands.`
+
+2. **引数エラー**
+   - `Usage: <correct usage>`
+   - 例: `Usage: Teleport X Y Z`
+
+3. **実行不可**
+   - 対象が存在しない場合: `No player character found`
+   - 条件を満たさない場合: `Cannot execute in current state`
+
+### エッジケース
+
+1. **プレイヤー不在時**
+   - プレイヤー関連コマンドは警告を出して無視
+
+2. **無効なビルド**
+   - Shippingビルドではコマンドが登録されない
+   - `Debug commands are not available in this build`
+
+## 制約・前提条件
+
+### ビルド制限
+
+```cpp
+#if !UE_BUILD_SHIPPING
+// デバッグコマンドの実装
+#endif
+```
+
+### 依存関係
+
+- **Engine**: 基本機能
+- **GameplayTags**: コマンドカテゴリ管理（オプション）
+
+### パフォーマンス要件
+
+- コマンド登録/解除: 即時
+- コマンド実行: 1フレーム以内に完了
+- メモリ: コマンドあたり約1KB以下
+
+## セキュリティ考慮
+
+1. **Shippingビルド除外**
+   - すべてのデバッグコマンドはShippingビルドで無効化
+
+2. **ネットワーク考慮**
+   - サーバー権限チェック（将来のマルチプレイ対応）
+   - クライアントからの不正なコマンド実行防止
+
+## 使用例
+
+### コンソールからの使用
+
+```
+# 無敵モード有効化
+God
+
+# 座標(100, 200, 300)へテレポート
+Teleport 100 200 300
+
+# HPを50に設定
+SetHP 50
+
+# 敵を3体スポーン
+SpawnEnemy BP_CombatEnemy 3
+
+# ゲーム速度を半分に
+SlowMo 0.5
+
+# 利用可能なコマンド一覧
+ListCommands
+
+# Teleportコマンドのヘルプ
+Help Teleport
+```
+
+### Blueprintからの使用
+
+```cpp
+// デバッグコマンドを実行
+FString Result;
+UDebugCommandBlueprintLibrary::ExecuteDebugCommand(
+    GetWorld(),
+    TEXT("SpawnEnemy BP_CombatEnemy 5"),
+    Result
+);
+```
+
+## テスト計画
+
+1. **ユニットテスト**
+   - 各コマンドの引数パース
+   - 正常系/異常系の動作確認
+
+2. **統合テスト**
+   - コンソールからの実行
+   - Blueprintからの実行
+   - Variant_Combatとの連携
+
+3. **ビルドテスト**
+   - Developmentビルドで有効確認
+   - Shippingビルドで無効確認
+
+## 今後の拡張
+
+1. **イベントログビューア連携**
+   - コマンド実行履歴をログに記録
+
+2. **セーブ/ロードデバッグ連携**
+   - `SaveState <SlotName>` コマンド追加
+   - `LoadState <SlotName>` コマンド追加
+
+3. **ビジュアルコマンドパレット**
+   - IMGUIベースのコマンド選択UI

--- a/docs/specs/debug-event-log-viewer.md
+++ b/docs/specs/debug-event-log-viewer.md
@@ -1,0 +1,402 @@
+# Debug Event Log Viewer Plugin
+
+## 概要
+
+ゲーム内イベントをリアルタイムで記録・表示するプラグイン。ダメージ、ステート遷移、アビリティ発動などのイベント履歴を時系列で確認でき、バグの原因特定を支援する。
+
+## 基本情報
+
+| 項目 | 値 |
+|------|-----|
+| プラグイン名 | DebugEventLogViewer |
+| モジュールタイプ | Runtime (DeveloperOnly) |
+| ロードフェーズ | Default |
+| 対象ビルド | Editor, Development のみ |
+
+## 要件
+
+### 必須要件
+
+1. **イベント記録システム**
+   - タイムスタンプ付きでイベントを記録
+   - カテゴリ別にイベントを分類
+   - 重要度レベル（Info, Warning, Error）
+   - 最大保持件数を設定可能（デフォルト: 1000件）
+
+2. **対応イベントカテゴリ**
+   - **Combat**: ダメージ、HP変化、死亡、リスポーン
+   - **State**: ステート遷移、アビリティ状態変化
+   - **AI**: AI行動決定、ターゲット変更、パス検索
+   - **Input**: 入力イベント（オプション、大量になるため）
+   - **System**: レベルロード、ポーズ、GameMode変更
+   - **Custom**: ユーザー定義イベント
+
+3. **表示UI**
+   - オーバーレイウィジェットでリアルタイム表示
+   - フィルタリング機能（カテゴリ、重要度、Actor別）
+   - 一時停止/再開機能
+   - ログのクリア機能
+   - スクロール可能なリスト表示
+
+4. **出力機能**
+   - ファイルへのエクスポート（CSV, JSON）
+   - クリップボードへのコピー
+
+### オプション要件
+
+1. **検索機能**
+   - キーワード検索
+   - 時間範囲指定
+
+2. **ブックマーク**
+   - 重要なイベントにマークを付ける
+   - マーク位置へジャンプ
+
+3. **イベント関連付け**
+   - 関連するイベントをグループ化
+   - 例: 攻撃開始→ダメージ→死亡を一連のイベントとして表示
+
+## アーキテクチャ
+
+### クラス構成
+
+```
+UEventLogSubsystem (UGameInstanceSubsystem)
+├── LogEvent()             # イベント記録
+├── GetEvents()            # イベント取得
+├── ClearEvents()          # ログクリア
+├── SetFilter()            # フィルタ設定
+├── ExportToFile()         # ファイル出力
+└── OnEventLogged          # イベント記録時デリゲート
+
+FDebugEvent (構造体)
+├── Timestamp              # タイムスタンプ（FDateTime + ゲーム時間）
+├── Category               # カテゴリ（EDebugEventCategory）
+├── Severity               # 重要度（EDebugEventSeverity）
+├── Message                # メッセージ
+├── SourceActor            # 発生元Actor（WeakPtr）
+├── TargetActor            # 対象Actor（WeakPtr）
+├── AdditionalData         # 追加データ（TMap<FString, FString>）
+└── FrameNumber            # フレーム番号
+
+UEventLogWidget (UUserWidget)
+├── EventListView          # イベントリスト
+├── FilterPanel            # フィルタパネル
+├── SearchBox              # 検索ボックス
+└── ControlButtons         # 制御ボタン
+
+UEventLogBlueprintLibrary (UBlueprintFunctionLibrary)
+├── LogDebugEvent()        # BPからイベント記録
+├── ToggleEventLogUI()     # UI表示切替
+└── ExportEventLog()       # エクスポート
+```
+
+### モジュール構成
+
+```
+DebugEventLogViewer/
+├── DebugEventLogViewer.uplugin
+├── Content/
+│   └── UI/
+│       └── WBP_EventLogViewer.uasset  # UIウィジェット
+└── Source/
+    └── DebugEventLogViewer/
+        ├── DebugEventLogViewer.Build.cs
+        ├── Public/
+        │   ├── DebugEventLogViewerModule.h
+        │   ├── EventLogSubsystem.h
+        │   ├── DebugEvent.h
+        │   ├── EventLogWidget.h
+        │   └── EventLogBlueprintLibrary.h
+        └── Private/
+            ├── DebugEventLogViewerModule.cpp
+            ├── EventLogSubsystem.cpp
+            ├── EventLogWidget.cpp
+            ├── EventLogBlueprintLibrary.cpp
+            └── Listeners/
+                ├── CombatEventListener.cpp    # 戦闘イベント監視
+                ├── StateEventListener.cpp     # ステート変化監視
+                ├── AIEventListener.cpp        # AIイベント監視
+                └── SystemEventListener.cpp    # システムイベント監視
+```
+
+## インターフェース
+
+### イベント記録
+
+```cpp
+// カテゴリ定義
+UENUM(BlueprintType)
+enum class EDebugEventCategory : uint8
+{
+    Combat      UMETA(DisplayName = "Combat"),
+    State       UMETA(DisplayName = "State"),
+    AI          UMETA(DisplayName = "AI"),
+    Input       UMETA(DisplayName = "Input"),
+    System      UMETA(DisplayName = "System"),
+    Custom      UMETA(DisplayName = "Custom")
+};
+
+// 重要度定義
+UENUM(BlueprintType)
+enum class EDebugEventSeverity : uint8
+{
+    Info        UMETA(DisplayName = "Info"),
+    Warning     UMETA(DisplayName = "Warning"),
+    Error       UMETA(DisplayName = "Error")
+};
+
+// イベント記録関数
+UFUNCTION(BlueprintCallable, Category="Debug Event Log")
+void LogEvent(
+    EDebugEventCategory Category,
+    EDebugEventSeverity Severity,
+    const FString& Message,
+    AActor* SourceActor = nullptr,
+    AActor* TargetActor = nullptr,
+    const TMap<FString, FString>& AdditionalData = TMap<FString, FString>()
+);
+```
+
+### イベント取得
+
+```cpp
+// フィルタ構造体
+USTRUCT(BlueprintType)
+struct FEventLogFilter
+{
+    GENERATED_BODY()
+
+    UPROPERTY(BlueprintReadWrite)
+    TArray<EDebugEventCategory> Categories;
+
+    UPROPERTY(BlueprintReadWrite)
+    TArray<EDebugEventSeverity> Severities;
+
+    UPROPERTY(BlueprintReadWrite)
+    FString KeywordFilter;
+
+    UPROPERTY(BlueprintReadWrite)
+    TWeakObjectPtr<AActor> ActorFilter;
+
+    UPROPERTY(BlueprintReadWrite)
+    float TimeRangeSeconds = 0.0f;  // 0 = 無制限
+};
+
+// イベント取得
+UFUNCTION(BlueprintCallable, Category="Debug Event Log")
+TArray<FDebugEvent> GetEvents(const FEventLogFilter& Filter) const;
+```
+
+### UI制御
+
+```cpp
+// UI表示切替
+UFUNCTION(BlueprintCallable, Category="Debug Event Log")
+void ToggleEventLogUI();
+
+// 一時停止/再開
+UFUNCTION(BlueprintCallable, Category="Debug Event Log")
+void SetPaused(bool bPaused);
+```
+
+## 振る舞い
+
+### 正常系
+
+1. **イベント記録**
+   - イベントが発生するとリングバッファに記録
+   - UIが表示中の場合はリアルタイム更新
+   - デリゲートで外部に通知
+
+2. **UI表示**
+   - デフォルトキー（`F10`）でトグル
+   - 新しいイベントは上部に追加
+   - 自動スクロール（設定で無効化可能）
+
+3. **フィルタリング**
+   - フィルタ変更時に即座に表示更新
+   - 複数フィルタはAND条件
+
+### エラー時
+
+1. **バッファオーバーフロー**
+   - 最大件数超過時は古いイベントから削除
+   - 警告は出さない（想定動作）
+
+2. **Actor参照切れ**
+   - 削除されたActorは「<Destroyed>」と表示
+   - フィルタリングには影響しない
+
+### パフォーマンス考慮
+
+1. **高頻度イベント**
+   - Inputイベントはデフォルト無効
+   - スロットリング設定（同一イベントの連続記録を抑制）
+
+2. **UI更新**
+   - バッチ更新（フレームごとにまとめて更新）
+   - 非表示時はUI更新をスキップ
+
+## 制約・前提条件
+
+### ビルド制限
+
+```cpp
+#if !UE_BUILD_SHIPPING
+// イベントログ機能の実装
+#endif
+```
+
+### 依存関係
+
+- **Engine**: 基本機能
+- **UMG**: UIウィジェット
+- **Slate**: カスタムUIコンポーネント
+
+### メモリ要件
+
+- デフォルト: 最大1000件保持
+- 1件あたり約500バイト
+- 最大使用メモリ: 約500KB〜1MB
+
+## 自動イベント収集
+
+### Combat連携（Variant_Combat）
+
+```cpp
+// ICombatDamageableのApplyDamage時に自動記録
+void ACombatCharacter::ApplyDamage(float Damage, AActor* DamageCauser, ...)
+{
+#if !UE_BUILD_SHIPPING
+    if (auto* EventLog = GetGameInstance()->GetSubsystem<UEventLogSubsystem>())
+    {
+        EventLog->LogEvent(
+            EDebugEventCategory::Combat,
+            EDebugEventSeverity::Info,
+            FString::Printf(TEXT("Damage: %.1f from %s"), Damage, *GetNameSafe(DamageCauser)),
+            DamageCauser,
+            this,
+            {
+                {TEXT("Damage"), FString::Printf(TEXT("%.1f"), Damage)},
+                {TEXT("RemainingHP"), FString::Printf(TEXT("%.1f"), CurrentHP)}
+            }
+        );
+    }
+#endif
+}
+```
+
+### AI連携
+
+```cpp
+// StateTree遷移時に自動記録
+// BehaviorTree実行時に自動記録
+// AIControllerのターゲット変更時に自動記録
+```
+
+## UI設計
+
+### レイアウト
+
+```
++--------------------------------------------------+
+| Event Log                          [_][□][×]     |
++--------------------------------------------------+
+| [▼Category] [▼Severity] [Search...      ] [Clear]|
++--------------------------------------------------+
+| ● 12:34:56.789 [Combat] Player took 25 damage    |
+| ● 12:34:56.500 [AI] Enemy_01 changed target      |
+| ○ 12:34:55.123 [State] Player: Idle -> Running   |
+| ● 12:34:54.000 [Combat] Enemy_02 spawned         |
+| ...                                              |
++--------------------------------------------------+
+| Items: 156 | Paused: No | [Export] [Copy]        |
++--------------------------------------------------+
+```
+
+### 色分け
+
+- **Info**: 白/グレー
+- **Warning**: 黄色
+- **Error**: 赤
+
+### カテゴリアイコン
+
+- **Combat**: ⚔️ 剣
+- **State**: 🔄 矢印
+- **AI**: 🤖 ロボット
+- **Input**: ⌨️ キーボード
+- **System**: ⚙️ 歯車
+- **Custom**: 📌 ピン
+
+## 使用例
+
+### コードからの使用
+
+```cpp
+// イベント記録
+if (auto* EventLog = GetGameInstance()->GetSubsystem<UEventLogSubsystem>())
+{
+    EventLog->LogEvent(
+        EDebugEventCategory::Custom,
+        EDebugEventSeverity::Warning,
+        TEXT("Player entered danger zone"),
+        PlayerCharacter,
+        DangerZoneActor
+    );
+}
+```
+
+### Blueprintからの使用
+
+```
+// ノード: Log Debug Event
+// Category: Custom
+// Severity: Info
+// Message: "Quest objective completed"
+// Source Actor: Self
+```
+
+### DebugConsoleCommands連携
+
+```
+# イベントログUI表示
+ShowEventLog
+
+# イベントログをファイルに出力
+ExportEventLog events.json
+
+# イベントログをクリア
+ClearEventLog
+
+# カテゴリでフィルタ
+FilterEventLog Combat
+```
+
+## テスト計画
+
+1. **ユニットテスト**
+   - イベント記録と取得
+   - フィルタリング
+   - バッファオーバーフロー
+
+2. **統合テスト**
+   - Variant_Combatとの連携
+   - UIの表示・操作
+   - エクスポート機能
+
+3. **パフォーマンステスト**
+   - 高頻度イベント記録時のFPS影響
+   - メモリ使用量
+
+## 今後の拡張
+
+1. **ネットワークログ**
+   - マルチプレイ時のRPC呼び出し記録
+
+2. **リプレイ連携**
+   - イベントログとリプレイの同期
+
+3. **Visual Logger連携**
+   - UE標準のVisual Loggerとの統合

--- a/docs/specs/debug-state-snapshot.md
+++ b/docs/specs/debug-state-snapshot.md
@@ -1,0 +1,547 @@
+# Debug State Snapshot Plugin
+
+## 概要
+
+ゲーム状態のスナップショットを保存・復元するプラグイン。バグ再現やテストシナリオの作成を支援する。任意の時点でゲーム状態を保存し、後で復元できる。
+
+## 基本情報
+
+| 項目 | 値 |
+|------|-----|
+| プラグイン名 | DebugStateSnapshot |
+| モジュールタイプ | Runtime (DeveloperOnly) |
+| ロードフェーズ | Default |
+| 対象ビルド | Editor, Development のみ |
+
+## 要件
+
+### 必須要件
+
+1. **スナップショット保存**
+   - 名前付きスロットに状態を保存
+   - 自動保存（チェックポイント通過時など）
+   - クイックセーブ（1キーで即座に保存）
+   - 保存対象の選択（全体/プレイヤーのみ/特定Actor）
+
+2. **保存対象データ**
+   - **Player**: 位置、回転、HP、ステート、インベントリ
+   - **Enemies**: 位置、HP、AIステート、ターゲット
+   - **World**: 破壊可能オブジェクトの状態、ドアの開閉状態
+   - **GameMode**: スコア、進行状況、チェックポイント
+   - **Timestamp**: 保存日時、プレイ時間
+
+3. **スナップショット復元**
+   - 保存したスロットから状態を復元
+   - クイックロード（1キーで即座に復元）
+   - 部分復元（プレイヤーのみ復元など）
+
+4. **スナップショット管理**
+   - スロット一覧表示
+   - スナップショットの削除
+   - スナップショットの説明/メモ追加
+   - ファイルへのエクスポート/インポート
+
+5. **UI**
+   - シンプルなスナップショットマネージャーUI
+   - スロット選択、プレビュー情報表示
+   - 保存/復元/削除ボタン
+
+### オプション要件
+
+1. **差分表示**
+   - 現在の状態と保存状態の差分を表示
+
+2. **自動スナップショット**
+   - 一定時間ごとに自動保存
+   - ローテーション（古いものから削除）
+
+3. **シナリオ機能**
+   - 複数のスナップショットをシーケンスとして保存
+   - バグ再現手順の記録
+
+## アーキテクチャ
+
+### クラス構成
+
+```
+UStateSnapshotSubsystem (UGameInstanceSubsystem)
+├── SaveSnapshot()         # スナップショット保存
+├── LoadSnapshot()         # スナップショット復元
+├── DeleteSnapshot()       # スナップショット削除
+├── GetSnapshotList()      # スロット一覧取得
+├── GetSnapshotInfo()      # スナップショット情報取得
+├── ExportSnapshot()       # ファイルエクスポート
+├── ImportSnapshot()       # ファイルインポート
+└── OnSnapshotSaved/Loaded # デリゲート
+
+FStateSnapshot (構造体)
+├── SlotName               # スロット名
+├── Description            # 説明
+├── SavedTime              # 保存日時
+├── PlayTime               # プレイ時間
+├── LevelName              # レベル名
+├── ThumbnailData          # サムネイル画像（オプション）
+└── StateData              # 状態データ（シリアライズ済み）
+
+ISnapshotable (インターフェース)
+├── SaveToSnapshot()       # スナップショットへ保存
+├── LoadFromSnapshot()     # スナップショットから復元
+└── GetSnapshotId()        # 識別子取得
+
+USnapshotManagerWidget (UUserWidget)
+├── SlotListView           # スロットリスト
+├── InfoPanel              # 情報パネル
+├── ActionButtons          # アクションボタン
+└── QuickSlotIndicator     # クイックスロット表示
+
+USnapshotBlueprintLibrary (UBlueprintFunctionLibrary)
+├── QuickSave()            # クイックセーブ
+├── QuickLoad()            # クイックロード
+├── SaveToSlot()           # スロットに保存
+└── LoadFromSlot()         # スロットから復元
+```
+
+### モジュール構成
+
+```
+DebugStateSnapshot/
+├── DebugStateSnapshot.uplugin
+├── Content/
+│   └── UI/
+│       └── WBP_SnapshotManager.uasset
+└── Source/
+    └── DebugStateSnapshot/
+        ├── DebugStateSnapshot.Build.cs
+        ├── Public/
+        │   ├── DebugStateSnapshotModule.h
+        │   ├── StateSnapshotSubsystem.h
+        │   ├── StateSnapshot.h
+        │   ├── Snapshotable.h              # インターフェース
+        │   ├── SnapshotManagerWidget.h
+        │   └── SnapshotBlueprintLibrary.h
+        └── Private/
+            ├── DebugStateSnapshotModule.cpp
+            ├── StateSnapshotSubsystem.cpp
+            ├── SnapshotManagerWidget.cpp
+            ├── SnapshotBlueprintLibrary.cpp
+            └── Serializers/
+                ├── PlayerStateSerializer.cpp
+                ├── ActorStateSerializer.cpp
+                ├── WorldStateSerializer.cpp
+                └── GameModeStateSerializer.cpp
+```
+
+## インターフェース
+
+### スナップショット保存
+
+```cpp
+// 保存オプション
+USTRUCT(BlueprintType)
+struct FSnapshotSaveOptions
+{
+    GENERATED_BODY()
+
+    // スロット名（必須）
+    UPROPERTY(BlueprintReadWrite)
+    FString SlotName;
+
+    // 説明（オプション）
+    UPROPERTY(BlueprintReadWrite)
+    FString Description;
+
+    // 保存対象
+    UPROPERTY(BlueprintReadWrite)
+    bool bSavePlayer = true;
+
+    UPROPERTY(BlueprintReadWrite)
+    bool bSaveEnemies = true;
+
+    UPROPERTY(BlueprintReadWrite)
+    bool bSaveWorldState = true;
+
+    UPROPERTY(BlueprintReadWrite)
+    bool bSaveGameMode = true;
+
+    // サムネイル生成
+    UPROPERTY(BlueprintReadWrite)
+    bool bCaptureThumbnail = true;
+
+    // 特定Actorのみ保存（空なら全Actor）
+    UPROPERTY(BlueprintReadWrite)
+    TArray<AActor*> SpecificActors;
+};
+
+// 保存関数
+UFUNCTION(BlueprintCallable, Category="Debug Snapshot")
+bool SaveSnapshot(const FSnapshotSaveOptions& Options);
+
+// クイックセーブ
+UFUNCTION(BlueprintCallable, Category="Debug Snapshot")
+bool QuickSave();
+```
+
+### スナップショット復元
+
+```cpp
+// 復元オプション
+USTRUCT(BlueprintType)
+struct FSnapshotLoadOptions
+{
+    GENERATED_BODY()
+
+    // スロット名
+    UPROPERTY(BlueprintReadWrite)
+    FString SlotName;
+
+    // 復元対象
+    UPROPERTY(BlueprintReadWrite)
+    bool bLoadPlayer = true;
+
+    UPROPERTY(BlueprintReadWrite)
+    bool bLoadEnemies = true;
+
+    UPROPERTY(BlueprintReadWrite)
+    bool bLoadWorldState = true;
+
+    UPROPERTY(BlueprintReadWrite)
+    bool bLoadGameMode = true;
+
+    // レベル変更が必要な場合に自動遷移
+    UPROPERTY(BlueprintReadWrite)
+    bool bAutoTransitionLevel = true;
+};
+
+// 復元関数
+UFUNCTION(BlueprintCallable, Category="Debug Snapshot")
+bool LoadSnapshot(const FSnapshotLoadOptions& Options);
+
+// クイックロード
+UFUNCTION(BlueprintCallable, Category="Debug Snapshot")
+bool QuickLoad();
+```
+
+### ISnapshotableインターフェース
+
+```cpp
+UINTERFACE(MinimalAPI, Blueprintable)
+class USnapshotable : public UInterface
+{
+    GENERATED_BODY()
+};
+
+class ISnapshotable
+{
+    GENERATED_BODY()
+
+public:
+    // スナップショットへ状態を保存
+    virtual void SaveToSnapshot(FArchive& Ar) = 0;
+
+    // スナップショットから状態を復元
+    virtual void LoadFromSnapshot(FArchive& Ar) = 0;
+
+    // 一意の識別子を返す
+    virtual FString GetSnapshotId() const = 0;
+};
+```
+
+## 振る舞い
+
+### 正常系
+
+1. **保存フロー**
+   ```
+   SaveSnapshot呼び出し
+   → レベル名、時刻を記録
+   → ISnapshotableを実装したActorを収集
+   → 各ActorのSaveToSnapshotを呼び出し
+   → データをシリアライズ
+   → ファイルに書き込み（Saved/Snapshots/）
+   → サムネイル生成（オプション）
+   → 成功通知
+   ```
+
+2. **復元フロー**
+   ```
+   LoadSnapshot呼び出し
+   → スロット名でファイルを検索
+   → レベル確認（異なる場合は遷移）
+   → データをデシリアライズ
+   → 既存Actorを検索、なければスポーン
+   → 各ActorのLoadFromSnapshotを呼び出し
+   → 成功通知
+   ```
+
+3. **クイックセーブ/ロード**
+   - 専用スロット「QuickSave」を使用
+   - 確認ダイアログなし
+   - 画面に保存/復元通知を表示
+
+### エラー時
+
+1. **保存失敗**
+   - ディスク容量不足: 警告メッセージ表示
+   - 書き込み権限なし: エラーログ出力
+
+2. **復元失敗**
+   - スロットが存在しない: `Snapshot not found: <SlotName>`
+   - レベルが異なる: 自動遷移または警告
+   - データ破損: エラーログ、部分復元を試行
+
+3. **Actorが見つからない**
+   - 復元時にActorが削除されていた場合はスキップ
+   - ログに警告を出力
+
+### エッジケース
+
+1. **レベル遷移中**
+   - 保存/復元を拒否、警告メッセージ
+
+2. **異なるレベルのスナップショット**
+   - `bAutoTransitionLevel`がtrueならレベル遷移後に復元
+   - falseなら復元拒否
+
+## 制約・前提条件
+
+### ビルド制限
+
+```cpp
+#if !UE_BUILD_SHIPPING
+// スナップショット機能の実装
+#endif
+```
+
+### 依存関係
+
+- **Engine**: 基本機能
+- **UMG**: UIウィジェット
+
+### ストレージ
+
+- 保存場所: `Saved/Snapshots/`
+- ファイル形式: `.snapshot`（バイナリ）
+- 1スナップショットあたり: 100KB〜1MB（レベル規模による）
+- 最大スロット数: 制限なし（ディスク容量依存）
+
+## 保存対象の詳細
+
+### プレイヤー状態
+
+```cpp
+struct FPlayerSnapshotData
+{
+    FTransform Transform;           // 位置・回転
+    float CurrentHP;                // 現在HP
+    float MaxHP;                    // 最大HP
+    FName CurrentState;             // 現在のステート
+    TArray<FInventoryItem> Items;   // インベントリ
+    // Variant_Combat固有
+    int32 ComboCount;
+    bool bIsCharging;
+};
+```
+
+### 敵状態
+
+```cpp
+struct FEnemySnapshotData
+{
+    FString EnemyClass;             // 敵のクラス名
+    FTransform Transform;           // 位置・回転
+    float CurrentHP;                // HP
+    FName AIState;                  // AIステート
+    FString TargetActorId;          // ターゲット
+    bool bIsActive;                 // アクティブ状態
+};
+```
+
+### ワールド状態
+
+```cpp
+struct FWorldSnapshotData
+{
+    TMap<FString, bool> DestructibleStates;    // 破壊状態
+    TMap<FString, bool> DoorStates;            // ドア開閉
+    TMap<FString, FTransform> MovableActors;   // 移動可能Actor
+};
+```
+
+## UI設計
+
+### スナップショットマネージャー
+
+```
++--------------------------------------------------+
+| Snapshot Manager                      [_][□][×]  |
++--------------------------------------------------+
+| Quick Slot: QuickSave_01 (12:34:56)              |
+| [Quick Save (F5)] [Quick Load (F9)]              |
++--------------------------------------------------+
+| Saved Snapshots:                                 |
+| +----------------------------------------------+ |
+| | ● boss_fight_start     | 2025-01-15 14:30   | |
+| |   "Before boss battle" | Combat_Level       | |
+| +----------------------------------------------+ |
+| | ○ checkpoint_02        | 2025-01-15 14:15   | |
+| |   "After puzzle"       | Puzzle_Level       | |
+| +----------------------------------------------+ |
+| | ○ bug_repro_001        | 2025-01-14 10:00   | |
+| |   "Crash reproduction" | Combat_Level       | |
+| +----------------------------------------------+ |
++--------------------------------------------------+
+| Selected: boss_fight_start                       |
+| Level: Combat_Level | Play Time: 00:45:30        |
+| [Load] [Delete] [Export]  [New Snapshot]         |
++--------------------------------------------------+
+```
+
+### キーバインド
+
+| キー | 機能 |
+|------|------|
+| F5 | クイックセーブ |
+| F9 | クイックロード |
+| F10 | スナップショットマネージャー表示 |
+
+## DebugConsoleCommands連携
+
+```
+# クイックセーブ
+QuickSave
+
+# クイックロード
+QuickLoad
+
+# 名前付きスロットに保存
+SaveState boss_fight "Before boss battle"
+
+# スロットから復元
+LoadState boss_fight
+
+# スロット一覧
+ListSnapshots
+
+# スナップショット削除
+DeleteSnapshot old_save
+
+# エクスポート
+ExportSnapshot boss_fight C:/debug/boss_fight.snapshot
+```
+
+## EventLogViewer連携
+
+```cpp
+// スナップショット保存/復元時にイベントログに記録
+void UStateSnapshotSubsystem::SaveSnapshot(...)
+{
+    // 保存処理...
+
+#if !UE_BUILD_SHIPPING
+    if (auto* EventLog = GetGameInstance()->GetSubsystem<UEventLogSubsystem>())
+    {
+        EventLog->LogEvent(
+            EDebugEventCategory::System,
+            EDebugEventSeverity::Info,
+            FString::Printf(TEXT("Snapshot saved: %s"), *Options.SlotName)
+        );
+    }
+#endif
+}
+```
+
+## 使用例
+
+### コードからの使用
+
+```cpp
+// 保存
+if (auto* Snapshot = GetGameInstance()->GetSubsystem<UStateSnapshotSubsystem>())
+{
+    FSnapshotSaveOptions Options;
+    Options.SlotName = TEXT("before_boss");
+    Options.Description = TEXT("Before entering boss room");
+    Snapshot->SaveSnapshot(Options);
+}
+
+// 復元
+FSnapshotLoadOptions LoadOptions;
+LoadOptions.SlotName = TEXT("before_boss");
+Snapshot->LoadSnapshot(LoadOptions);
+```
+
+### Blueprintからの使用
+
+```
+// ノード: Quick Save
+// → 画面に "State Saved" と表示
+
+// ノード: Load Snapshot
+// Slot Name: "checkpoint_01"
+// Load Player: true
+// Load Enemies: true
+```
+
+### ISnapshotableの実装例
+
+```cpp
+// CombatCharacterでの実装
+class ACombatCharacter : public ACharacter, public ISnapshotable
+{
+    // ISnapshotable実装
+    virtual void SaveToSnapshot(FArchive& Ar) override
+    {
+        FTransform Transform = GetActorTransform();
+        Ar << Transform;
+        Ar << CurrentHP;
+        Ar << MaxHP;
+        // ...
+    }
+
+    virtual void LoadFromSnapshot(FArchive& Ar) override
+    {
+        FTransform Transform;
+        Ar << Transform;
+        SetActorTransform(Transform);
+        Ar << CurrentHP;
+        Ar << MaxHP;
+        // ...
+    }
+
+    virtual FString GetSnapshotId() const override
+    {
+        return GetName();
+    }
+};
+```
+
+## テスト計画
+
+1. **ユニットテスト**
+   - 保存/復元の整合性
+   - シリアライズ/デシリアライズ
+   - 複数スロット管理
+
+2. **統合テスト**
+   - Variant_Combatでの動作確認
+   - レベル遷移を伴う復元
+   - 他プラグインとの連携
+
+3. **ストレステスト**
+   - 大量のActor保存
+   - 連続保存/復元
+
+## 今後の拡張
+
+1. **クラウド同期**
+   - スナップショットのクラウド保存
+
+2. **共有機能**
+   - 他の開発者とスナップショット共有
+
+3. **タイムライン機能**
+   - 自動スナップショットの時系列表示
+   - 任意の時点への巻き戻し
+
+4. **差分スナップショット**
+   - 変更点のみ保存して容量削減


### PR DESCRIPTION
## Summary

- Implement DebugConsoleCommands plugin for developer debugging and testing
- Add 18+ console commands for gameplay testing across 6 categories
- Include specification documents for future debug plugins (EventLogViewer, StateSnapshot)

## Implemented Commands

| Category | Commands |
|----------|----------|
| Player | `God`, `Heal`, `Kill` |
| Movement | `Teleport`, `SetSpeed`, `Fly`, `Ghost` |
| Combat | `SetHP`, `SetMaxHP`, `KillAllEnemies`, `ToggleAI` |
| Spawn | `SpawnActor`, `SpawnEnemy` |
| System | `SlowMo`, `Pause`, `RestartLevel`, `OpenLevel`, `ShowFPS`, `ShowUnit` |
| Info | `ListCommands`, `Help`, `ShowStats`, `ShowPosition` |

## Usage

```
Debug <command> [args...]
Debug ListCommands        # Show all commands
Debug Help <command>      # Show command help
Debug God                 # Toggle invincibility
Debug Teleport 0 0 100    # Teleport to coordinates
```

## Architecture

- `UDebugCommandSubsystem`: GameInstance subsystem for command management
- `FDebugCommand`: Command structure with name, description, category, usage
- `UDebugCommandBlueprintLibrary`: Blueprint function library for BP integration
- Commands are only available in Editor/Development builds (disabled in Shipping)

## Test plan

- [ ] Verify plugin loads in Editor
- [ ] Test `Debug ListCommands` shows all commands
- [ ] Test `Debug God` toggles invincibility
- [ ] Test `Debug Teleport X Y Z` moves player
- [ ] Test `Debug SlowMo 0.5` changes game speed
- [ ] Verify commands are disabled in Shipping build

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)